### PR TITLE
Add fallback autoloader and package vendor during build

### DIFF
--- a/bin/build-zip.sh
+++ b/bin/build-zip.sh
@@ -6,6 +6,10 @@ PLUGIN_SLUG="fp-multilanguage"
 OUTPUT_DIR="$ROOT_DIR/build"
 ZIP_FILE="$OUTPUT_DIR/$PLUGIN_SLUG.zip"
 
+if [ -f "$ROOT_DIR/composer.json" ] && command -v composer >/dev/null 2>&1; then
+    (cd "$ROOT_DIR" && composer install --no-dev --optimize-autoloader)
+fi
+
 rm -rf "$OUTPUT_DIR"
 mkdir -p "$OUTPUT_DIR/$PLUGIN_SLUG"
 
@@ -29,6 +33,10 @@ rsync -av --exclude-from=- "$ROOT_DIR/$PLUGIN_SLUG/" "$OUTPUT_DIR/$PLUGIN_SLUG/"
 /QA_REPORT.md
 /vite.config.js
 RSYNC
+
+if [ -d "$ROOT_DIR/vendor" ]; then
+    rsync -av "$ROOT_DIR/vendor/" "$OUTPUT_DIR/$PLUGIN_SLUG/vendor/"
+fi
 
 (cd "$OUTPUT_DIR" && zip -r "$ZIP_FILE" "$PLUGIN_SLUG")
 

--- a/fp-multilanguage/fp-multilanguage.php
+++ b/fp-multilanguage/fp-multilanguage.php
@@ -32,9 +32,27 @@ if ( ! defined( 'FP_MULTILANGUAGE_VERSION' ) ) {
 	define( 'FP_MULTILANGUAGE_VERSION', '1.0.0' );
 }
 
-$autoload = FP_MULTILANGUAGE_PATH . '../vendor/autoload.php';
-if ( file_exists( $autoload ) ) {
-	require_once $autoload;
+$autoload_paths = array(
+        FP_MULTILANGUAGE_PATH . '../vendor/autoload.php',
+        FP_MULTILANGUAGE_PATH . 'vendor/autoload.php',
+);
+
+$is_autoloaded = false;
+
+foreach ( $autoload_paths as $autoload_path ) {
+        if ( file_exists( $autoload_path ) ) {
+                require_once $autoload_path;
+                $is_autoloaded = true;
+                break;
+        }
+}
+
+if ( ! $is_autoloaded ) {
+        $fallback_autoload = FP_MULTILANGUAGE_PATH . 'includes/autoload.php';
+
+        if ( file_exists( $fallback_autoload ) ) {
+                require_once $fallback_autoload;
+        }
 }
 
 use FPMultilanguage\Plugin;

--- a/fp-multilanguage/includes/autoload.php
+++ b/fp-multilanguage/includes/autoload.php
@@ -1,0 +1,18 @@
+<?php
+
+spl_autoload_register(
+        static function ( string $class ): void {
+                $prefix = 'FPMultilanguage\\';
+
+                if ( 0 !== strpos( $class, $prefix ) ) {
+                        return;
+                }
+
+                $relative_class = substr( $class, strlen( $prefix ) );
+                $file            = __DIR__ . '/' . str_replace( '\\', '/', $relative_class ) . '.php';
+
+                if ( is_readable( $file ) ) {
+                        require_once $file;
+                }
+        }
+);


### PR DESCRIPTION
## Summary
- add fallback loading logic in the main plugin file so it uses Composer's autoloader when present or a bundled fallback when not
- introduce a minimal PSR-4 autoloader under `includes/` for plugin classes
- run `composer install --no-dev` during the packaging script and copy the generated `vendor/` directory into the archive

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d3082af620832fbfb8367c280dfef8