### PR TITLE
Fix ngettext filter to respect translation parameter

### DIFF
--- a/fp-multilanguage/includes/Dynamic/DynamicStrings.php
+++ b/fp-multilanguage/includes/Dynamic/DynamicStrings.php
@@ -229,11 +229,20 @@ class DynamicStrings {
 		return $this->translate_string( $text, $context );
 	}
 
-	public function filter_ngettext( string $single, string $plural, int $number, string $domain ): string {
-		$text = $number === 1 ? $single : $plural;
+        public function filter_ngettext( string $translation, string $single, string $plural, int $number, string $domain ): string {
+                $text = $number === 1 ? $single : $plural;
 
-		return $this->filter_gettext( $text, $text, $domain );
-	}
+                if ( $translation !== $text ) {
+                        $result = $this->filter_gettext( $translation, $text, $domain );
+                        if ( $result !== $translation && $result !== $text ) {
+                                return $result;
+                        }
+
+                        return $translation;
+                }
+
+                return $this->filter_gettext( $translation, $text, $domain );
+        }
 
 	public function filter_generic_string( $value ) {
 		if ( ! is_string( $value ) || trim( $value ) === '' ) {

--- a/tests/DynamicStringsTest.php
+++ b/tests/DynamicStringsTest.php
@@ -122,6 +122,43 @@ class DynamicStringsTest extends TestCase
         $this->assertSame('service:Hello', $result);
     }
 
+    public function test_filter_ngettext_preserves_existing_wordpress_translation(): void
+    {
+        $service = $this->createMock(TranslationService::class);
+        $service->expects($this->never())->method('translate_text');
+        $dynamicStrings = $this->createDynamicStrings($service);
+
+        add_filter('fp_multilanguage_current_language', static function () {
+            return 'it';
+        });
+
+        $result = $dynamicStrings->filter_ngettext('Traduzione WP', 'Singolare', 'Plurale', 2, 'default');
+
+        $this->assertSame('Traduzione WP', $result);
+    }
+
+    public function test_filter_ngettext_triggers_automatic_translation_when_needed(): void
+    {
+        $service = $this->getMockBuilder(TranslationService::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['translate_text'])
+            ->getMock();
+
+        $service->expects($this->once())
+            ->method('translate_text')
+            ->with('Singolare', 'en', 'it', [])
+            ->willReturn('service:Singolare');
+
+        add_filter('fp_multilanguage_current_language', static function () {
+            return 'it';
+        });
+
+        $dynamicStrings = $this->createDynamicStrings($service);
+        $result = $dynamicStrings->filter_ngettext('Singolare', 'Singolare', 'Plurale', 1, 'default');
+
+        $this->assertSame('service:Singolare', $result);
+    }
+
     public function test_translates_requested_language_from_query_var(): void
     {
         $_GET['fp_lang'] = 'it';


### PR DESCRIPTION
## Summary
- align `DynamicStrings::filter_ngettext()` with WordPress' `ngettext` hook signature and reuse the gettext logic while preserving existing translations
- cover plural translations with new unit tests that exercise both existing translations and automatic translation fallback

## Testing
- vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68d3988cae94832f9f0d65d123de4945