### PR TITLE
Fix language switcher URL generation

### DIFF
--- a/fp-multilanguage/includes/Widgets/LanguageSwitcher.php
+++ b/fp-multilanguage/includes/Widgets/LanguageSwitcher.php
@@ -76,30 +76,77 @@ class LanguageSwitcher extends WP_Widget {
 		return '<ul class="fp-language-switcher">' . implode( '', $items ) . '</ul>';
 	}
 
-	private function get_languages(): array {
-		$post         = get_queried_object();
-		$translations = array();
-		if ( $post instanceof \WP_Post ) {
-			$manager      = fp_multilanguage()->get_container()->get( 'post_translation_manager' );
-			$translations = $manager->get_post_translations( $post->ID );
-		}
+        private function get_languages(): array {
+                $post         = get_queried_object();
+                $translations = array();
+                if ( $post instanceof \WP_Post ) {
+                        $manager      = fp_multilanguage()->get_container()->get( 'post_translation_manager' );
+                        $translations = $manager->get_post_translations( $post->ID );
+                }
 
-		$languages            = array();
-		$source               = Settings::get_source_language();
-		$languages[ $source ] = add_query_arg( 'fp_lang', $source, home_url( add_query_arg( array() ) ) );
+                $baseUrl = $this->resolve_base_url( $post );
+                $baseUrl = $this->append_current_query_args( $baseUrl );
 
-		foreach ( Settings::get_target_languages() as $language ) {
-			if ( $language === $source ) {
-				continue;
-			}
+                $languages            = array();
+                $source               = Settings::get_source_language();
+                $languages[ $source ] = add_query_arg( 'fp_lang', $source, $baseUrl );
 
-			if ( ! empty( $translations ) && empty( $translations[ $language ] ) ) {
-				continue;
-			}
+                foreach ( Settings::get_target_languages() as $language ) {
+                        if ( $language === $source ) {
+                                continue;
+                        }
 
-			$languages[ $language ] = add_query_arg( 'fp_lang', $language, home_url( add_query_arg( array() ) ) );
-		}
+                        if ( ! empty( $translations ) && empty( $translations[ $language ] ) ) {
+                                continue;
+                        }
 
-		return $languages;
-	}
+                        $languages[ $language ] = add_query_arg( 'fp_lang', $language, $baseUrl );
+                }
+
+                return $languages;
+        }
+
+        private function resolve_base_url( $post ): string {
+                if ( $post instanceof \WP_Post ) {
+                        return get_permalink( $post );
+                }
+
+                $requestUri = isset( $_SERVER['REQUEST_URI'] ) ? (string) $_SERVER['REQUEST_URI'] : '';
+                if ( $requestUri === '' ) {
+                        return home_url( '/' );
+                }
+
+                $parts = explode( '?', $requestUri, 2 );
+                $path  = $parts[0];
+
+                if ( $path === '' ) {
+                        $path = '/';
+                } elseif ( $path[0] !== '/' ) {
+                        $path = '/' . $path;
+                }
+
+                return home_url( $path );
+        }
+
+        private function append_current_query_args( string $baseUrl ): string {
+                if ( empty( $_GET ) || ! is_array( $_GET ) ) {
+                        return $baseUrl;
+                }
+
+                $queryArgs = array();
+
+                foreach ( wp_unslash( $_GET ) as $key => $value ) {
+                        if ( strtolower( (string) $key ) === 'fp_lang' ) {
+                                continue;
+                        }
+
+                        $queryArgs[ $key ] = $value;
+                }
+
+                if ( empty( $queryArgs ) ) {
+                        return $baseUrl;
+                }
+
+                return add_query_arg( $queryArgs, $baseUrl );
+        }
 }

--- a/tests/LanguageSwitcherTest.php
+++ b/tests/LanguageSwitcherTest.php
@@ -1,0 +1,175 @@
+<?php
+namespace {
+    if (! class_exists('WP_Post')) {
+        class WP_Post
+        {
+            public $ID;
+
+            public function __construct(array $data = [])
+            {
+                foreach ($data as $key => $value) {
+                    $this->{$key} = $value;
+                }
+            }
+        }
+    }
+
+    if (! class_exists('WP_Widget')) {
+        class WP_Widget
+        {
+            public function __construct($id_base = '', $name = '', $widget_options = [], $control_options = [])
+            {
+                unset($id_base, $name, $widget_options, $control_options);
+            }
+        }
+    }
+
+    if (! isset($GLOBALS['fpml_test_translations'])) {
+        $GLOBALS['fpml_test_translations'] = [];
+    }
+
+    if (! array_key_exists('fpml_test_queried_object', $GLOBALS)) {
+        $GLOBALS['fpml_test_queried_object'] = null;
+    }
+}
+
+namespace FPMultilanguage\Widgets {
+    if (! function_exists(__NAMESPACE__ . '\\fpml_set_test_queried_object')) {
+        function fpml_set_test_queried_object($object): void
+        {
+            $GLOBALS['fpml_test_queried_object'] = $object;
+        }
+    }
+
+    if (! function_exists(__NAMESPACE__ . '\\fpml_reset_test_state')) {
+        function fpml_reset_test_state(): void
+        {
+            $GLOBALS['fpml_test_queried_object'] = null;
+            $GLOBALS['fpml_test_translations'] = [];
+        }
+    }
+
+    if (! function_exists(__NAMESPACE__ . '\\get_queried_object')) {
+        function get_queried_object()
+        {
+            return $GLOBALS['fpml_test_queried_object'] ?? null;
+        }
+    }
+
+    if (! function_exists(__NAMESPACE__ . '\\fpml_set_post_translations')) {
+        function fpml_set_post_translations(int $postId, array $translations): void
+        {
+            if (! isset($GLOBALS['fpml_test_translations'])) {
+                $GLOBALS['fpml_test_translations'] = [];
+            }
+
+            $GLOBALS['fpml_test_translations'][$postId] = $translations;
+        }
+    }
+
+    if (! function_exists(__NAMESPACE__ . '\\fp_multilanguage')) {
+        function fp_multilanguage()
+        {
+            return new class() {
+                public function get_container()
+                {
+                    return new class() {
+                        public function get($id)
+                        {
+                            if ($id === 'post_translation_manager') {
+                                return new class() {
+                                    public function get_post_translations($postId)
+                                    {
+                                        return $GLOBALS['fpml_test_translations'][$postId] ?? [];
+                                    }
+                                };
+                            }
+
+                            return null;
+                        }
+                    };
+                }
+            };
+        }
+    }
+}
+
+namespace FPMultilanguage\Tests {
+
+use FPMultilanguage\Admin\Settings;
+use FPMultilanguage\Widgets\LanguageSwitcher;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+class LanguageSwitcherTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        global $wp_test_options;
+        $wp_test_options = [];
+
+        \FPMultilanguage\Widgets\fpml_reset_test_state();
+
+        Settings::bootstrap_defaults();
+
+        $_GET = [];
+        $_SERVER['REQUEST_URI'] = '/';
+    }
+
+    protected function tearDown(): void
+    {
+        \FPMultilanguage\Widgets\fpml_reset_test_state();
+
+        $_GET = [];
+        unset($_SERVER['REQUEST_URI']);
+
+        parent::tearDown();
+    }
+
+    public function test_generates_permalink_urls_preserving_query_string(): void
+    {
+        $post = new \WP_Post(['ID' => 42]);
+        \FPMultilanguage\Widgets\fpml_set_test_queried_object($post);
+
+        $_SERVER['REQUEST_URI'] = '/post/42/?foo=bar&fp_lang=it';
+        $_GET = [
+            'foo' => 'bar',
+            'fp_lang' => 'it',
+        ];
+
+        $switcher = new LanguageSwitcher();
+        $languages = $this->invokeGetLanguages($switcher);
+
+        $this->assertSame('https://example.com/post/42?foo=bar&fp_lang=en', $languages['en']);
+        $this->assertSame('https://example.com/post/42?foo=bar&fp_lang=it', $languages['it']);
+    }
+
+    public function test_generates_home_urls_preserving_query_string_for_non_singular(): void
+    {
+        \FPMultilanguage\Widgets\fpml_set_test_queried_object(null);
+
+        $_SERVER['REQUEST_URI'] = '/category/news/?paged=2&fp_lang=en';
+        $_GET = [
+            'paged' => '2',
+            'fp_lang' => 'en',
+        ];
+
+        $switcher = new LanguageSwitcher();
+        $languages = $this->invokeGetLanguages($switcher);
+
+        $this->assertSame('https://example.com/category/news/?paged=2&fp_lang=en', $languages['en']);
+        $this->assertSame('https://example.com/category/news/?paged=2&fp_lang=it', $languages['it']);
+    }
+
+    private function invokeGetLanguages(LanguageSwitcher $switcher): array
+    {
+        $reflection = new ReflectionClass(LanguageSwitcher::class);
+        $method = $reflection->getMethod('get_languages');
+        $method->setAccessible(true);
+
+        return $method->invoke($switcher);
+    }
+}
+}


### PR DESCRIPTION
## Summary
- resolve the language switcher base URL without wrapping add_query_arg() in home_url()
- preserve existing query parameters when building language URLs for singular and non-singular contexts
- cover the new behaviour with LanguageSwitcherTest verifying generated URLs

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d39ae63fa0832f85096edbe6a01d49