### PR TITLE
Handle optional nav menu arguments in filter

### DIFF
--- a/fp-multilanguage/includes/Dynamic/DynamicStrings.php
+++ b/fp-multilanguage/includes/Dynamic/DynamicStrings.php
@@ -244,8 +244,8 @@ class DynamicStrings {
                 return $this->filter_gettext( $translation, $text, $domain );
         }
 
-	public function filter_generic_string( $value, ...$args ) {
-		unset( $args );
+        public function filter_generic_string( $value, $item = null, $depth = null, $args = null ) {
+                unset( $item, $depth, $args );
 
 		if ( ! is_string( $value ) || trim( $value ) === '' ) {
 			return $value;


### PR DESCRIPTION
## Summary
- allow `DynamicStrings::filter_generic_string` to accept optional arguments from the `nav_menu_item_title` filter and ignore them

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d39ec48938832fbde9b2b4a02e50c4