### PR TITLE
Fix logger factory signature

### DIFF
--- a/fp-multilanguage/includes/Plugin.php
+++ b/fp-multilanguage/includes/Plugin.php
@@ -151,7 +151,9 @@ class Plugin {
 		if ( ! $container->has( 'logger' ) ) {
 			$container->set(
 				'logger',
-				static function (): Logger {
+				static function ( Container $container ): Logger {
+					unset( $container );
+
 					return new Logger();
 				}
 			);


### PR DESCRIPTION
## Summary
- update the logger service registration so the container-injected parameter matches the Container::get invocation
- silence the unused service parameter to keep static analysis and coding standards happy

## Testing
- php /workspace/test_bootstrap.php

------
https://chatgpt.com/codex/tasks/task_e_68d3a178dc28832f9f1e4253bf61dba3