### PR TITLE
Add edit capability flag and localized prompts for dynamic strings

### DIFF
--- a/fp-multilanguage/assets/js/dynamic-translations.js
+++ b/fp-multilanguage/assets/js/dynamic-translations.js
@@ -5,6 +5,10 @@
     var manualStrings = config.manualStrings || {};
     var language = config.language || '';
     var canEdit = !!config.canEdit;
+    var prompts = config.prompts || {};
+    var editPrompt = typeof prompts.edit === 'string' && prompts.edit.length > 0
+        ? prompts.edit
+        : 'Traduzione manuale';
 
     function getManualValue(key) {
         if (manualStrings[key] && manualStrings[key][language]) {
@@ -31,7 +35,7 @@
                 element.classList.add('fp-multilanguage-editable');
                 element.addEventListener('dblclick', function () {
                     var current = manualValue !== null ? manualValue : element.innerText;
-                    var value = window.prompt(config.prompts && config.prompts.edit ? config.prompts.edit : 'Traduzione manuale', current);
+                    var value = window.prompt(editPrompt, current);
                     if (value === null) {
                         return;
                     }

--- a/fp-multilanguage/includes/Dynamic/DynamicStrings.php
+++ b/fp-multilanguage/includes/Dynamic/DynamicStrings.php
@@ -73,17 +73,21 @@ class DynamicStrings {
 		$language      = CurrentLanguage::resolve();
 
 		wp_enqueue_script( 'fp-multilanguage-dynamic' );
-		wp_localize_script(
-			'fp-multilanguage-dynamic',
-			'fpMultilanguageDynamic',
-			array(
-				'ajaxUrl'       => admin_url( 'admin-ajax.php' ),
-				'nonce'         => wp_create_nonce( 'fp_multilanguage_manual_string' ),
-				'language'      => $language,
-				'manualStrings' => $manualStrings,
-				'restUrl'       => rest_url( 'fp-multilanguage/v1/strings' ),
-			)
-		);
+                wp_localize_script(
+                        'fp-multilanguage-dynamic',
+                        'fpMultilanguageDynamic',
+                        array(
+                                'ajaxUrl'       => admin_url( 'admin-ajax.php' ),
+                                'nonce'         => wp_create_nonce( 'fp_multilanguage_manual_string' ),
+                                'language'      => $language,
+                                'manualStrings' => $manualStrings,
+                                'restUrl'       => rest_url( 'fp-multilanguage/v1/strings' ),
+                                'canEdit'       => current_user_can( 'manage_options' ),
+                                'prompts'       => array(
+                                        'edit' => __( 'Inserisci la traduzione manuale', 'fp-multilanguage' ),
+                                ),
+                        )
+                );
 
 		if ( ! wp_script_is( 'fp-multilanguage-frontend', 'enqueued' ) ) {
 			wp_enqueue_script( 'fp-multilanguage-frontend' );

--- a/tests/DynamicStringsTest.php
+++ b/tests/DynamicStringsTest.php
@@ -20,7 +20,7 @@ class DynamicStringsTest extends TestCase
     {
         parent::setUp();
 
-        global $wp_test_options, $wp_test_cache, $wp_test_transients, $wp_remote_post_calls, $wp_test_filters, $wp_test_actions, $wp_test_textdomains;
+        global $wp_test_options, $wp_test_cache, $wp_test_transients, $wp_remote_post_calls, $wp_test_filters, $wp_test_actions, $wp_test_textdomains, $wp_localized_scripts;
         $wp_test_options = [];
         $wp_test_cache = [];
         $wp_test_transients = [];
@@ -28,6 +28,7 @@ class DynamicStringsTest extends TestCase
         $wp_test_filters = [];
         $wp_test_actions = [];
         $wp_test_textdomains = [];
+        $wp_localized_scripts = [];
         $_GET = [];
 
         Settings::bootstrap_defaults();
@@ -215,5 +216,35 @@ class DynamicStringsTest extends TestCase
         $result = $dynamicStrings->translate_dynamic_string('Hello world');
 
         $this->assertSame('service:Hello world', $result);
+    }
+
+    public function test_enqueue_assets_localizes_capabilities_and_prompts(): void
+    {
+        global $wp_localized_scripts;
+
+        if (! defined('FP_MULTILANGUAGE_URL')) {
+            define('FP_MULTILANGUAGE_URL', 'https://example.com/wp-content/plugins/fp-multilanguage/');
+        }
+
+        if (! defined('FP_MULTILANGUAGE_VERSION')) {
+            define('FP_MULTILANGUAGE_VERSION', '1.0.0');
+        }
+
+        $service = $this->createMock(TranslationService::class);
+        $dynamicStrings = $this->createDynamicStrings($service);
+
+        $dynamicStrings->enqueue_assets();
+
+        $this->assertArrayHasKey('fp-multilanguage-dynamic', $wp_localized_scripts);
+        $this->assertArrayHasKey('fpMultilanguageDynamic', $wp_localized_scripts['fp-multilanguage-dynamic']);
+
+        $data = $wp_localized_scripts['fp-multilanguage-dynamic']['fpMultilanguageDynamic'];
+
+        $this->assertArrayHasKey('canEdit', $data);
+        $this->assertTrue($data['canEdit']);
+
+        $this->assertArrayHasKey('prompts', $data);
+        $this->assertArrayHasKey('edit', $data['prompts']);
+        $this->assertSame(__('Inserisci la traduzione manuale', 'fp-multilanguage'), $data['prompts']['edit']);
     }
 }


### PR DESCRIPTION
## Summary
- add the `canEdit` flag and localized edit prompt to the dynamic strings script localization
- update the front-end script to leverage the localized edit prompt when editing manual translations
- cover the localized configuration with a unit test for `DynamicStrings::enqueue_assets`

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d3af768138832f9a547d9f183ea4ea