### PR TITLE
Align translation persistence and slug routing for production readiness

### DIFF
--- a/fp-multilanguage/fp-multilanguage.php
+++ b/fp-multilanguage/fp-multilanguage.php
@@ -33,26 +33,26 @@ if ( ! defined( 'FP_MULTILANGUAGE_VERSION' ) ) {
 }
 
 $autoload_paths = array(
-        FP_MULTILANGUAGE_PATH . '../vendor/autoload.php',
-        FP_MULTILANGUAGE_PATH . 'vendor/autoload.php',
+	FP_MULTILANGUAGE_PATH . '../vendor/autoload.php',
+	FP_MULTILANGUAGE_PATH . 'vendor/autoload.php',
 );
 
 $is_autoloaded = false;
 
 foreach ( $autoload_paths as $autoload_path ) {
-        if ( file_exists( $autoload_path ) ) {
-                require_once $autoload_path;
-                $is_autoloaded = true;
-                break;
-        }
+	if ( file_exists( $autoload_path ) ) {
+			require_once $autoload_path;
+			$is_autoloaded = true;
+			break;
+	}
 }
 
 if ( ! $is_autoloaded ) {
-        $fallback_autoload = FP_MULTILANGUAGE_PATH . 'includes/autoload.php';
+		$fallback_autoload = FP_MULTILANGUAGE_PATH . 'includes/autoload.php';
 
-        if ( file_exists( $fallback_autoload ) ) {
-                require_once $fallback_autoload;
-        }
+	if ( file_exists( $fallback_autoload ) ) {
+			require_once $fallback_autoload;
+	}
 }
 
 use FPMultilanguage\Plugin;

--- a/fp-multilanguage/includes/Admin/Settings.php
+++ b/fp-multilanguage/includes/Admin/Settings.php
@@ -352,7 +352,7 @@ class Settings {
 	}
 
 	private function render_quote_tab(): void {
-		$quotes = $this->get_options()['quote_tracking'] ?? array();
+			$quotes = TranslationService::get_usage_stats();
 		?>
 		<table class="widefat striped">
 			<thead>
@@ -364,21 +364,25 @@ class Settings {
 				</tr>
 			</thead>
 			<tbody>
-				<?php if ( empty( $quotes ) ) : ?>
+			<?php if ( empty( $quotes ) ) : ?>
 					<tr>
 						<td colspan="4"><?php esc_html_e( 'Nessun dato disponibile. Le quote verranno aggiornate dopo le prime traduzioni.', 'fp-multilanguage' ); ?></td>
 					</tr>
 				<?php else : ?>
-					<?php foreach ( $quotes as $provider => $data ) : ?>
-						<?php foreach ( $data as $language => $usage ) : ?>
-							<tr>
-								<td><?php echo esc_html( $provider ); ?></td>
-								<td><?php echo esc_html( $language ); ?></td>
-								<td><?php echo esc_html( number_format_i18n( $usage['characters'] ?? 0 ) ); ?></td>
-								<td><?php echo esc_html( isset( $usage['updated_at'] ) ? date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), (int) $usage['updated_at'] ) : '-' ); ?></td>
-							</tr>
-						<?php endforeach; ?>
-					<?php endforeach; ?>
+										<?php foreach ( $quotes as $provider => $data ) : ?>
+												<?php foreach ( $data as $language => $usage ) : ?>
+														<?php
+														$characters = (int) $usage['characters'];
+														$updated_at = (int) $usage['updated_at'];
+														?>
+														<tr>
+																<td><?php echo esc_html( $provider ); ?></td>
+																<td><?php echo esc_html( $language ); ?></td>
+																<td><?php echo esc_html( number_format_i18n( $characters ) ); ?></td>
+																<td><?php echo esc_html( $updated_at > 0 ? date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $updated_at ) : '-' ); ?></td>
+														</tr>
+												<?php endforeach; ?>
+										<?php endforeach; ?>
 				<?php endif; ?>
 			</tbody>
 		</table>

--- a/fp-multilanguage/includes/Content/PostTranslationManager.php
+++ b/fp-multilanguage/includes/Content/PostTranslationManager.php
@@ -71,15 +71,15 @@ class PostTranslationManager {
 			return;
 		}
 
-               if ( ! in_array( $post->post_type, array( 'post', 'page' ), true ) ) {
-                       return;
-               }
+		if ( ! in_array( $post->post_type, array( 'post', 'page' ), true ) ) {
+				return;
+		}
 
-               if ( ! Settings::is_auto_translate_enabled() ) {
-                       return;
-               }
+		if ( ! Settings::is_auto_translate_enabled() ) {
+				return;
+		}
 
-               $this->translate_post( $postId );
+				$this->translate_post( $postId );
 	}
 
 	public function translate_post( int $postId, ?string $language = null, bool $force = false ): array {
@@ -94,48 +94,105 @@ class PostTranslationManager {
 			$targetLanguages = array_intersect( $targetLanguages, array( $language ) );
 		}
 
-		$translations = $this->get_post_translations( $postId );
-		$customFields = $this->get_custom_fields( $post );
-		$hasChanges   = false;
+				$translations  = $this->get_post_translations( $postId );
+				$customFields  = $this->get_custom_fields( $post );
+				$hasChanges    = false;
+				$titleHash     = $this->hash_value( $post->post_title );
+				$contentHash   = $this->hash_value( $post->post_content );
+				$excerptSource = $post->post_excerpt !== '' ? $post->post_excerpt : wp_trim_words( $post->post_content, 55 );
+				$excerptHash   = $this->hash_value( $excerptSource );
+				$metaHashes    = array();
+		foreach ( $customFields as $metaKey => $value ) {
+				$metaHashes[ $metaKey ] = $this->hash_value( (string) $value );
+		}
 
 		foreach ( $targetLanguages as $target ) {
 			if ( $target === $sourceLanguage ) {
-				continue;
+						continue;
 			}
 
-			$existing           = $translations[ $target ] ?? array();
-			$updated            = $existing;
-			$languageHasChanges = $force;
+				$existing           = $translations[ $target ] ?? array();
+				$updated            = $existing;
+				$languageHasChanges = $force;
 
-			$title = $this->translationService->translate_text( $post->post_title, $sourceLanguage, $target );
-			if ( ! isset( $existing['title'] ) || $existing['title'] !== $title ) {
-				$updated['title']   = $title;
-				$languageHasChanges = true;
+				$existingSource = array();
+			if ( isset( $existing['source'] ) && is_array( $existing['source'] ) ) {
+							$existingSource = $existing['source'];
 			}
 
-			$content = $this->translationService->translate_text( $post->post_content, $sourceLanguage, $target, array( 'format' => 'html' ) );
-			if ( ! isset( $existing['content'] ) || $existing['content'] !== $content ) {
-				$updated['content'] = $content;
-				$languageHasChanges = true;
+							$updatedSource = array(
+								'title'   => $existingSource['title'] ?? null,
+								'content' => $existingSource['content'] ?? null,
+								'excerpt' => $existingSource['excerpt'] ?? null,
+								'meta'    => is_array( $existingSource['meta'] ?? null ) ? $existingSource['meta'] : array(),
+							);
+
+							$languageHasChanges = $this->sync_field_translation(
+								$updated,
+								$existing,
+								$updatedSource,
+								'title',
+								$post->post_title,
+								$titleHash,
+								$sourceLanguage,
+								$target,
+								array(),
+								$force
+							) || $languageHasChanges;
+
+				$languageHasChanges = $this->sync_field_translation(
+					$updated,
+					$existing,
+					$updatedSource,
+					'content',
+					$post->post_content,
+					$contentHash,
+					$sourceLanguage,
+					$target,
+					array( 'format' => 'html' ),
+					$force
+				) || $languageHasChanges;
+
+				$languageHasChanges = $this->sync_field_translation(
+					$updated,
+					$existing,
+					$updatedSource,
+					'excerpt',
+					$excerptSource,
+					$excerptHash,
+					$sourceLanguage,
+					$target,
+					array( 'format' => 'html' ),
+					$force
+				) || $languageHasChanges;
+
+				list( $metaTranslations, $metaSource, $metaChanged ) = $this->sync_meta_translations(
+					$existing,
+					$updatedSource['meta'],
+					$customFields,
+					$metaHashes,
+					$sourceLanguage,
+					$target,
+					$force
+				);
+
+			if ( ! empty( $metaTranslations ) ) {
+				$updated['meta'] = $metaTranslations;
+			} elseif ( isset( $updated['meta'] ) ) {
+						unset( $updated['meta'] );
 			}
 
-			$excerptSource = $post->post_excerpt !== '' ? $post->post_excerpt : wp_trim_words( $post->post_content, 55 );
-			$excerpt       = $this->translationService->translate_text( $excerptSource, $sourceLanguage, $target, array( 'format' => 'html' ) );
-			if ( ! isset( $existing['excerpt'] ) || $existing['excerpt'] !== $excerpt ) {
-				$updated['excerpt'] = $excerpt;
-				$languageHasChanges = true;
-			}
-
-			$updated['meta'] = $existing['meta'] ?? array();
-			foreach ( $customFields as $metaKey => $value ) {
-				$translatedMeta = $this->translationService->translate_text( (string) $value, $sourceLanguage, $target );
-				if ( ! isset( $updated['meta'][ $metaKey ] ) || $updated['meta'][ $metaKey ] !== $translatedMeta ) {
-					$updated['meta'][ $metaKey ] = $translatedMeta;
-					$languageHasChanges          = true;
-				}
+				$updatedSource['meta'] = $metaSource;
+				$languageHasChanges    = $languageHasChanges || $metaChanged;
+				$existingMetaKeys      = array_keys( is_array( $existing['meta'] ?? null ) ? $existing['meta'] : array() );
+				$currentMetaKeys       = array_keys( $customFields );
+				$removedMetaKeys       = array_diff( $existingMetaKeys, $currentMetaKeys );
+			if ( ! empty( $removedMetaKeys ) ) {
+							$languageHasChanges = true;
 			}
 
 			if ( $languageHasChanges ) {
+				$updated['source']       = $updatedSource;
 				$updated['updated_at']   = time();
 				$updated['status']       = 'synced';
 				$translations[ $target ] = $updated;
@@ -144,7 +201,7 @@ class PostTranslationManager {
 		}
 
 		if ( $hasChanges ) {
-			update_post_meta( $postId, self::META_KEY, $translations );
+				update_post_meta( $postId, self::META_KEY, $translations );
 		}
 
 		$this->persist_relations( $postId, $translations, $sourceLanguage );
@@ -284,22 +341,111 @@ class PostTranslationManager {
 				return $default_value;
 		}
 
-			$translations = $this->get_post_translations( $post->ID );
+		$translations = $this->get_post_translations( $post->ID );
 		if ( isset( $translations[ $language ][ $field ] ) && $translations[ $language ][ $field ] !== '' ) {
 				return $translations[ $language ][ $field ];
 		}
 
-			$translated = $this->translationService->translate_text( $default_value, $source, $language, $options );
+		$translated = $this->translationService->translate_text( $default_value, $source, $language, $options );
 		if ( $translated !== '' ) {
 				return $translated;
 		}
 
-			$fallback = Settings::get_fallback_language();
+		$fallback = Settings::get_fallback_language();
 		if ( $fallback !== $language && isset( $translations[ $fallback ][ $field ] ) ) {
 				return $translations[ $fallback ][ $field ];
 		}
 
 			return $default_value;
+	}
+
+	private function hash_value( string $value ): string {
+			return hash( 'sha1', $value );
+	}
+
+	private function sync_field_translation(
+		array &$updated,
+		array $existing,
+		array &$updatedSource,
+		string $field,
+		string $value,
+		string $hash,
+		string $sourceLanguage,
+		string $targetLanguage,
+		array $options,
+		bool $force
+	): bool {
+			$hasChanges       = false;
+			$existingValue    = $existing[ $field ] ?? null;
+			$existingSource   = $updatedSource[ $field ] ?? null;
+			$needsTranslation = $force || ! is_string( $existingSource ) || $existingSource !== $hash || ! is_string( $existingValue );
+
+		if ( ! $needsTranslation ) {
+				return false;
+		}
+
+			$translated = $this->translationService->translate_text( $value, $sourceLanguage, $targetLanguage, $options );
+		if ( $translated === '' ) {
+				$translated = is_string( $existingValue ) ? $existingValue : $value;
+		}
+
+		if ( ! is_string( $existingValue ) || $existingValue !== $translated ) {
+				$updated[ $field ] = $translated;
+				$hasChanges        = true;
+		}
+
+		if ( $existingSource !== $hash ) {
+				$hasChanges = true;
+		}
+
+			$updatedSource[ $field ] = $hash;
+
+			return $hasChanges;
+	}
+
+	private function sync_meta_translations(
+		array $existing,
+		array $existingSource,
+		array $customFields,
+		array $metaHashes,
+		string $sourceLanguage,
+		string $targetLanguage,
+		bool $force
+	): array {
+			$updatedMeta       = array();
+			$updatedMetaSource = array();
+			$hasChanges        = false;
+			$existingMeta      = is_array( $existing['meta'] ?? null ) ? $existing['meta'] : array();
+
+		foreach ( $customFields as $metaKey => $value ) {
+				$hash             = $metaHashes[ $metaKey ] ?? $this->hash_value( (string) $value );
+				$existingValue    = $existingMeta[ $metaKey ] ?? null;
+				$existingMetaHash = $existingSource[ $metaKey ] ?? null;
+				$needsTranslation = $force || ! is_string( $existingMetaHash ) || $existingMetaHash !== $hash || ! is_string( $existingValue );
+
+			if ( $needsTranslation ) {
+				$translated = $this->translationService->translate_text( (string) $value, $sourceLanguage, $targetLanguage );
+				if ( $translated === '' ) {
+						$translated = is_string( $existingValue ) ? $existingValue : (string) $value;
+				}
+
+				if ( ! is_string( $existingValue ) || $existingValue !== $translated ) {
+						$hasChanges = true;
+				}
+
+				if ( $existingMetaHash !== $hash ) {
+						$hasChanges = true;
+				}
+
+				$updatedMeta[ $metaKey ] = $translated;
+			} elseif ( is_string( $existingValue ) ) {
+					$updatedMeta[ $metaKey ] = $existingValue;
+			}
+
+				$updatedMetaSource[ $metaKey ] = $hash;
+		}
+
+			return array( $updatedMeta, $updatedMetaSource, $hasChanges );
 	}
 
 	/**

--- a/fp-multilanguage/includes/Dynamic/DynamicStrings.php
+++ b/fp-multilanguage/includes/Dynamic/DynamicStrings.php
@@ -73,21 +73,21 @@ class DynamicStrings {
 		$language      = CurrentLanguage::resolve();
 
 		wp_enqueue_script( 'fp-multilanguage-dynamic' );
-                wp_localize_script(
-                        'fp-multilanguage-dynamic',
-                        'fpMultilanguageDynamic',
-                        array(
-                                'ajaxUrl'       => admin_url( 'admin-ajax.php' ),
-                                'nonce'         => wp_create_nonce( 'fp_multilanguage_manual_string' ),
-                                'language'      => $language,
-                                'manualStrings' => $manualStrings,
-                                'restUrl'       => rest_url( 'fp-multilanguage/v1/strings' ),
-                                'canEdit'       => current_user_can( 'manage_options' ),
-                                'prompts'       => array(
-                                        'edit' => __( 'Inserisci la traduzione manuale', 'fp-multilanguage' ),
-                                ),
-                        )
-                );
+				wp_localize_script(
+					'fp-multilanguage-dynamic',
+					'fpMultilanguageDynamic',
+					array(
+						'ajaxUrl'       => admin_url( 'admin-ajax.php' ),
+						'nonce'         => wp_create_nonce( 'fp_multilanguage_manual_string' ),
+						'language'      => $language,
+						'manualStrings' => $manualStrings,
+						'restUrl'       => rest_url( 'fp-multilanguage/v1/strings' ),
+						'canEdit'       => current_user_can( 'manage_options' ),
+						'prompts'       => array(
+							'edit' => __( 'Inserisci la traduzione manuale', 'fp-multilanguage' ),
+						),
+					)
+				);
 
 		if ( ! wp_script_is( 'fp-multilanguage-frontend', 'enqueued' ) ) {
 			wp_enqueue_script( 'fp-multilanguage-frontend' );
@@ -237,29 +237,36 @@ class DynamicStrings {
 	}
 
 
-        public function filter_ngettext( string $translation, string $single, string $plural, int $number, string $domain ): string {
-                $text = $number === 1 ? $single : $plural;
+	public function filter_ngettext( string $translation, string $single, string $plural, int $number, string $domain ): string {
+			$text = $number === 1 ? $single : $plural;
 
-                if ( $translation !== $text ) {
-                        $result = $this->filter_gettext( $translation, $text, $domain );
-                        if ( $result !== $translation && $result !== $text ) {
-                                return $result;
-                        }
+		if ( $translation !== $text ) {
+				$result = $this->filter_gettext( $translation, $text, $domain );
+			if ( $result !== $translation && $result !== $text ) {
+				return $result;
+			}
 
-                        return $translation;
-                }
-
-                return $this->filter_gettext( $translation, $text, $domain );
-        }
-
-        public function filter_generic_string( $value, $item = null, $depth = null, $args = null ) {
-                unset( $item, $depth, $args );
-
-		if ( ! is_string( $value ) || trim( $value ) === '' ) {
-			return $value;
+				return $translation;
 		}
 
-		return $this->translate_string( $value, 'generic' );
+			return $this->filter_gettext( $translation, $text, $domain );
+	}
+
+		/**
+		 * @param mixed $item  Optional context object provided by the filter.
+		 * @param mixed $depth Optional depth parameter provided by the filter.
+		 * @param mixed $args  Optional arguments provided by the filter.
+		 *
+		 * @return mixed
+		 */
+	public function filter_generic_string( $value, $item = null, $depth = null, $args = null ) {
+			unset( $item, $depth, $args );
+
+		if ( ! is_string( $value ) || trim( $value ) === '' ) {
+				return $value;
+		}
+
+			return $this->translate_string( $value, 'generic' );
 	}
 
 	private function translate_string( string $text, string $identifier = '', array $args = array() ): string {
@@ -306,7 +313,7 @@ class DynamicStrings {
 		}
 
 		return '';
-}
+	}
 
 	private function store_string( string $key, string $original, string $context ): void {
 		global $wpdb;

--- a/fp-multilanguage/includes/Plugin.php
+++ b/fp-multilanguage/includes/Plugin.php
@@ -120,12 +120,13 @@ class Plugin {
 	}
 
 	public static function activate(): void {
-		$instance = self::instance();
-		$instance->register_services();
+			$instance = self::instance();
+			$instance->register_services();
+			Settings::bootstrap_defaults();
 
-		/** @var Migrator $migrator */
-		$migrator = $instance->container->get( 'migrator' );
-		$migrator->maybe_migrate();
+			/** @var Migrator $migrator */
+			$migrator = $instance->container->get( 'migrator' );
+			$migrator->maybe_migrate();
 
 		update_option( self::VERSION_OPTION, FP_MULTILANGUAGE_VERSION );
 	}
@@ -135,14 +136,15 @@ class Plugin {
 	}
 
 	public static function uninstall(): void {
-		delete_option( Settings::OPTION_NAME );
-		delete_option( Settings::MANUAL_STRINGS_OPTION );
-		delete_option( 'fp_multilanguage_quota' );
-		delete_option( self::VERSION_OPTION );
+			delete_option( Settings::OPTION_NAME );
+			delete_option( Settings::MANUAL_STRINGS_OPTION );
+			delete_option( 'fp_multilanguage_quota' );
+			delete_option( self::VERSION_OPTION );
+			delete_option( 'fp_multilanguage_slug_index' );
 
-		/** @var Migrator $migrator */
-		$migrator = self::instance()->container->get( 'migrator' );
-		$migrator->drop_tables();
+			/** @var Migrator $migrator */
+			$migrator = self::instance()->container->get( 'migrator' );
+			$migrator->drop_tables();
 	}
 
 	private function register_services(): void {

--- a/fp-multilanguage/includes/SEO/SEO.php
+++ b/fp-multilanguage/includes/SEO/SEO.php
@@ -12,6 +12,8 @@ class SEO {
 
 	private const META_KEY = '_fp_multilanguage_seo';
 
+	private const SLUG_INDEX_OPTION = 'fp_multilanguage_slug_index';
+
 	private Settings $settings;
 
 	private TranslationService $translationService;
@@ -28,14 +30,16 @@ class SEO {
 	}
 
 	public function register(): void {
-		add_action( 'add_meta_boxes', array( $this, 'add_meta_box' ) );
-		add_action( 'save_post', array( $this, 'save_meta' ), 20, 2 );
-		add_action( 'wp_head', array( $this, 'render_meta_tags' ), 1 );
-		add_filter( 'pre_get_document_title', array( $this, 'filter_document_title' ) );
-		add_filter( 'wp_sitemaps_posts_entry', array( $this, 'filter_sitemap_entry' ), 10, 3 );
-		add_filter( 'wpseo_locale', array( $this, 'filter_wpseo_locale' ) );
-		add_filter( 'wpseo_canonical', array( $this, 'filter_wpseo_canonical' ) );
-		add_filter( 'robots_txt', array( $this, 'filter_robots_txt' ), 10, 2 );
+			add_action( 'add_meta_boxes', array( $this, 'add_meta_box' ) );
+			add_action( 'save_post', array( $this, 'save_meta' ), 20, 2 );
+			add_action( 'wp_head', array( $this, 'render_meta_tags' ), 1 );
+			add_filter( 'pre_get_document_title', array( $this, 'filter_document_title' ) );
+			add_filter( 'wp_sitemaps_posts_entry', array( $this, 'filter_sitemap_entry' ), 10, 3 );
+			add_filter( 'wpseo_locale', array( $this, 'filter_wpseo_locale' ) );
+			add_filter( 'wpseo_canonical', array( $this, 'filter_wpseo_canonical' ) );
+			add_filter( 'robots_txt', array( $this, 'filter_robots_txt' ), 10, 2 );
+			add_filter( 'request', array( $this, 'resolve_slug_request' ) );
+			add_action( 'delete_post', array( $this, 'handle_post_delete' ) );
 	}
 
 	public function add_meta_box(): void {
@@ -125,7 +129,12 @@ class SEO {
 			}
 		}
 
-		update_post_meta( $postId, self::META_KEY, $sanitized );
+				update_post_meta( $postId, self::META_KEY, $sanitized );
+				$this->update_slug_index( $postId, $sanitized['slug'] );
+	}
+
+	public function handle_post_delete( int $postId ): void {
+			$this->remove_from_slug_index( $postId );
 	}
 
 	public function render_meta_tags(): void {
@@ -244,32 +253,31 @@ class SEO {
 	}
 
 	public function filter_sitemap_entry( array $entry, WP_Post $post, string $postType ): array {
-		unset( $postType );
+			unset( $postType );
 
-		$languageUrls = $this->get_language_urls( $post, $this->get_meta( $post->ID ) );
-                if ( ! empty( $languageUrls ) ) {
-                        $entry['alternates'] = array();
-                        foreach ( $languageUrls as $lang => $url ) {
-                                $entry['alternates'][] = array(
-                                        'rel'      => 'alternate',
-                                        'hreflang' => $lang,
-                                        'href'     => $url,
-                                );
-                        }
-                }
+			$languageUrls = $this->get_language_urls( $post, $this->get_meta( $post->ID ) );
+		if ( ! empty( $languageUrls ) ) {
+			$entry['alternates'] = array();
+			foreach ( $languageUrls as $lang => $url ) {
+						$entry['alternates'][] = array(
+							'rel'      => 'alternate',
+							'hreflang' => $lang,
+							'href'     => $url,
+						);
+			}
+		}
 
-		return $entry;
+			return $entry;
 	}
 
 	public function filter_robots_txt( string $output, bool $is_public ): string {
 		if ( ! $is_public ) {
-			return $output;
+				return $output;
 		}
 
-			$language = CurrentLanguage::resolve();
-		if ( $language !== '' && strpos( $output, 'Sitemap:' ) === false ) {
-			$output .= "\n# FP Multilanguage";
-			$output .= "\nSitemap: " . home_url( '/sitemap-' . $language . '.xml' );
+		if ( strpos( $output, 'Sitemap:' ) === false ) {
+				$output .= "\n# FP Multilanguage";
+				$output .= "\nSitemap: " . home_url( '/wp-sitemap.xml' );
 		}
 
 			return $output;
@@ -296,28 +304,173 @@ class SEO {
 	}
 
 	private function get_language_urls( WP_Post $post, array $meta ): array {
-		$urls         = array();
-		$source       = Settings::get_source_language();
-		$translations = $this->postTranslationManager->get_post_translations( $post->ID );
+			$urls         = array();
+			$source       = Settings::get_source_language();
+			$translations = $this->postTranslationManager->get_post_translations( $post->ID );
 
-		$urls[ $source ] = get_permalink( $post );
+			$urls[ $source ] = get_permalink( $post );
 		if ( isset( $meta['slug'][ $source ] ) && $meta['slug'][ $source ] !== '' ) {
-			$urls[ $source ] = trailingslashit( home_url( $meta['slug'][ $source ] ) );
+				$sourceSlug = $this->normalize_slug( $meta['slug'][ $source ] );
+			if ( $sourceSlug !== '' ) {
+				$urls[ $source ] = trailingslashit( home_url( $sourceSlug ) );
+			}
 		}
 
 		foreach ( $translations as $language => $data ) {
 			if ( ! isset( $data['content'] ) || $data['content'] === '' ) {
-				continue;
+					continue;
 			}
 
-			$slug = $meta['slug'][ $language ] ?? '';
+				$slug = $meta['slug'][ $language ] ?? '';
+				$slug = $this->normalize_slug( $slug );
 			if ( $slug !== '' ) {
-				$urls[ $language ] = trailingslashit( home_url( $slug ) );
+					$urls[ $language ] = trailingslashit( home_url( $slug ) );
 			} else {
-				$urls[ $language ] = add_query_arg( 'fp_lang', $language, get_permalink( $post ) );
+					$urls[ $language ] = add_query_arg( 'fp_lang', $language, get_permalink( $post ) );
 			}
 		}
 
-		return $urls;
+			return $urls;
+	}
+
+	public function resolve_slug_request( array $queryVars ): array {
+		if ( is_admin() ) {
+				return $queryVars;
+		}
+
+		if ( ( defined( 'REST_REQUEST' ) && REST_REQUEST ) || isset( $queryVars['rest_route'] ) ) {
+				return $queryVars;
+		}
+
+		if ( isset( $queryVars['p'] ) || isset( $queryVars['page_id'] ) ) {
+				return $queryVars;
+		}
+
+			$path = '';
+		if ( isset( $_SERVER['REQUEST_URI'] ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+				$path = (string) $_SERVER['REQUEST_URI']; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		}
+
+			$parsed     = (string) parse_url( $path, PHP_URL_PATH );
+			$normalized = trim( $parsed, '/' );
+		if ( $normalized === '' || strpos( $normalized, 'wp-admin' ) === 0 || strpos( $normalized, 'wp-json' ) === 0 ) {
+				return $queryVars;
+		}
+
+			$index  = self::get_slug_index();
+			$byPath = is_array( $index['by_path'] ?? null ) ? $index['by_path'] : array();
+		if ( ! isset( $byPath[ $normalized ] ) ) {
+				return $queryVars;
+		}
+
+			$mapping  = $byPath[ $normalized ];
+			$postId   = (int) ( $mapping['post_id'] ?? 0 );
+			$language = isset( $mapping['language'] ) ? sanitize_key( (string) $mapping['language'] ) : '';
+
+		if ( $postId <= 0 ) {
+				return $queryVars;
+		}
+
+			$queryVars['p']       = $postId;
+			$queryVars['page_id'] = $postId;
+
+		if ( $language !== '' ) {
+				$queryVars['fp_lang'] = $language;
+		}
+
+			unset( $queryVars['name'], $queryVars['pagename'] );
+
+			return $queryVars;
+	}
+
+	public static function get_language_slugs( int $postId ): array {
+			$index  = self::get_slug_index();
+			$byPost = is_array( $index['by_post'] ?? null ) ? $index['by_post'] : array();
+
+		if ( isset( $byPost[ $postId ] ) && is_array( $byPost[ $postId ] ) ) {
+				return $byPost[ $postId ];
+		}
+
+			return array();
+	}
+
+	private static function get_slug_index(): array {
+			$stored = get_option( self::SLUG_INDEX_OPTION, array() );
+		if ( ! is_array( $stored ) ) {
+				return array(
+					'by_path' => array(),
+					'by_post' => array(),
+				);
+		}
+
+			$defaults = array(
+				'by_path' => array(),
+				'by_post' => array(),
+			);
+
+			return wp_parse_args( $stored, $defaults );
+	}
+
+	private function update_slug_index( int $postId, array $slugs ): void {
+			$index = self::get_slug_index();
+
+		foreach ( $index['by_path'] as $path => $data ) {
+			if ( (int) ( $data['post_id'] ?? 0 ) === $postId ) {
+				unset( $index['by_path'][ $path ] );
+			}
+		}
+
+			unset( $index['by_post'][ $postId ] );
+
+		foreach ( $slugs as $language => $slug ) {
+				$languageKey = sanitize_key( (string) $language );
+				$normalized  = $this->normalize_slug( (string) $slug );
+
+			if ( $languageKey === '' || $normalized === '' ) {
+					continue;
+			}
+
+				$index['by_path'][ $normalized ] = array(
+					'post_id'  => $postId,
+					'language' => $languageKey,
+				);
+
+				if ( ! isset( $index['by_post'][ $postId ] ) ) {
+						$index['by_post'][ $postId ] = array();
+				}
+
+				$index['by_post'][ $postId ][ $languageKey ] = $normalized;
+		}
+
+			update_option( self::SLUG_INDEX_OPTION, $index );
+	}
+
+	private function remove_from_slug_index( int $postId ): void {
+			$index   = self::get_slug_index();
+			$changed = false;
+
+		foreach ( $index['by_path'] as $path => $data ) {
+			if ( (int) ( $data['post_id'] ?? 0 ) === $postId ) {
+				unset( $index['by_path'][ $path ] );
+				$changed = true;
+			}
+		}
+
+		if ( isset( $index['by_post'][ $postId ] ) ) {
+				unset( $index['by_post'][ $postId ] );
+				$changed = true;
+		}
+
+		if ( $changed ) {
+				update_option( self::SLUG_INDEX_OPTION, $index );
+		}
+	}
+
+	private function normalize_slug( string $slug ): string {
+			$slug = trim( $slug );
+
+			$slug = trim( $slug, '/' );
+
+			return $slug;
 	}
 }

--- a/fp-multilanguage/includes/Services/TranslationService.php
+++ b/fp-multilanguage/includes/Services/TranslationService.php
@@ -125,11 +125,20 @@ class TranslationService {
 
 	public static function flush_cache(): void {
 		if ( function_exists( 'update_option' ) ) {
-			$version = (int) get_option( self::CACHE_VERSION_OPTION, 1 );
-			update_option( self::CACHE_VERSION_OPTION, $version + 1 );
+				$version = (int) get_option( self::CACHE_VERSION_OPTION, 1 );
+				update_option( self::CACHE_VERSION_OPTION, $version + 1 );
 		}
 
-		self::$runtimeCache = array();
+			self::$runtimeCache = array();
+	}
+
+		/**
+		 * @return array<string, array<string, array{requests:int,characters:int,updated_at:int}>>
+		 */
+	public static function get_usage_stats(): array {
+			$stored = get_option( self::QUOTA_OPTION, array() );
+
+			return is_array( $stored ) ? $stored : array();
 	}
 
 	/**
@@ -355,16 +364,13 @@ class TranslationService {
 		update_option( self::QUOTA_OPTION, $quota );
 	}
 
-	/**
-	 * @return array<string, array<string, array{requests:int,characters:int,updated_at:int}>>
-	 */
+		/**
+		 * @return array<string, array<string, array{requests:int,characters:int,updated_at:int}>>
+		 */
 	private function get_quota(): array {
-		$stored = get_option( self::QUOTA_OPTION, array() );
-		if ( ! is_array( $stored ) ) {
-			return array();
-		}
+			$stored = self::get_usage_stats();
 
-		return $stored;
+			return $stored;
 	}
 
 	protected function get_text_length( string $text ): int {

--- a/fp-multilanguage/includes/Widgets/LanguageSwitcher.php
+++ b/fp-multilanguage/includes/Widgets/LanguageSwitcher.php
@@ -3,8 +3,14 @@ namespace FPMultilanguage\Widgets;
 
 use FPMultilanguage\Admin\Settings;
 use FPMultilanguage\CurrentLanguage;
+use FPMultilanguage\SEO\SEO;
+use WP_Post;
 use WP_Widget;
 
+/**
+ * @method string get_field_id( string $field_name )
+ * @method string get_field_name( string $field_name )
+ */
 class LanguageSwitcher extends WP_Widget {
 
 	public function __construct() {
@@ -15,10 +21,14 @@ class LanguageSwitcher extends WP_Widget {
 		);
 	}
 
+		/**
+		 * @param array<string, mixed> $args
+		 * @param array<string, mixed> $instance
+		 */
 	public function widget( $args, $instance ): void {
-		echo $args['before_widget'] ?? '';
+			echo $args['before_widget'] ?? '';
 
-		$title = isset( $instance['title'] ) ? apply_filters( 'widget_title', $instance['title'] ) : __( 'Lingue', 'fp-multilanguage' );
+			$title = isset( $instance['title'] ) ? apply_filters( 'widget_title', $instance['title'] ) : __( 'Lingue', 'fp-multilanguage' );
 		if ( $title !== '' ) {
 			echo $args['before_title'] ?? '';
 			echo esc_html( $title );
@@ -30,21 +40,32 @@ class LanguageSwitcher extends WP_Widget {
 		echo $args['after_widget'] ?? '';
 	}
 
+		/**
+		 * @param array<string, mixed> $instance
+		 */
 	public function form( $instance ): void {
-		$title = isset( $instance['title'] ) ? (string) $instance['title'] : '';
+			$title      = isset( $instance['title'] ) ? (string) $instance['title'] : '';
+			$field_id   = $this->get_field_id( 'title' );
+			$field_name = $this->get_field_name( 'title' );
 		?>
-		<p>
-			<label for="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>"><?php esc_html_e( 'Titolo:', 'fp-multilanguage' ); ?></label>
-			<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>" type="text" value="<?php echo esc_attr( $title ); ?>">
-		</p>
-		<?php
+				<p>
+						<label for="<?php echo esc_attr( $field_id ); ?>"><?php esc_html_e( 'Titolo:', 'fp-multilanguage' ); ?></label>
+						<input class="widefat" id="<?php echo esc_attr( $field_id ); ?>" name="<?php echo esc_attr( $field_name ); ?>" type="text" value="<?php echo esc_attr( $title ); ?>">
+				</p>
+				<?php
 	}
 
-	public function update( $newInstance, $oldInstance ) {
-		$instance          = $oldInstance;
-		$instance['title'] = sanitize_text_field( $newInstance['title'] ?? '' );
+		/**
+		 * @param array<string, mixed> $newInstance
+		 * @param array<string, mixed> $oldInstance
+		 *
+		 * @return array<string, mixed>
+		 */
+	public function update( $newInstance, $oldInstance ): array {
+			$instance          = $oldInstance;
+			$instance['title'] = sanitize_text_field( $newInstance['title'] ?? '' );
 
-		return $instance;
+			return $instance;
 	}
 
 	public function render_shortcode( array $atts = array() ): string {
@@ -60,10 +81,10 @@ class LanguageSwitcher extends WP_Widget {
 	}
 
 	private function render_switcher( string $layout = 'list' ): string {
-		$languages = $this->get_languages();
-		$current   = CurrentLanguage::resolve();
+			$languages = $this->get_languages();
+			$current   = CurrentLanguage::resolve();
 
-		$items = array();
+			$items = array();
 		foreach ( $languages as $language => $url ) {
 			$class   = $language === $current ? ' class="current-language"' : '';
 			$items[] = sprintf( '<li%s><a href="%s">%s</a></li>', $class, esc_url( $url ), esc_html( strtoupper( $language ) ) );
@@ -73,80 +94,95 @@ class LanguageSwitcher extends WP_Widget {
 			return '<ul class="fp-language-switcher inline">' . implode( ' ', $items ) . '</ul>';
 		}
 
-		return '<ul class="fp-language-switcher">' . implode( '', $items ) . '</ul>';
+			return '<ul class="fp-language-switcher">' . implode( '', $items ) . '</ul>';
 	}
 
-        private function get_languages(): array {
-                $post         = get_queried_object();
-                $translations = array();
-                if ( $post instanceof \WP_Post ) {
-                        $manager      = fp_multilanguage()->get_container()->get( 'post_translation_manager' );
-                        $translations = $manager->get_post_translations( $post->ID );
-                }
+		/**
+		 * @return array<string, string>
+		 */
+	private function get_languages(): array {
+			$post         = get_queried_object();
+			$translations = array();
+		if ( $post instanceof WP_Post ) {
+				$manager      = fp_multilanguage()->get_container()->get( 'post_translation_manager' );
+				$translations = $manager->get_post_translations( $post->ID );
+		}
 
-                $baseUrl = $this->resolve_base_url( $post );
-                $baseUrl = $this->append_current_query_args( $baseUrl );
+						$baseUrl = $this->resolve_base_url( $post );
+						$slugs   = $post instanceof WP_Post ? SEO::get_language_slugs( $post->ID ) : array();
 
-                $languages            = array();
-                $source               = Settings::get_source_language();
-                $languages[ $source ] = add_query_arg( 'fp_lang', $source, $baseUrl );
+						$languages            = array();
+						$source               = Settings::get_source_language();
+						$languages[ $source ] = $this->build_language_url( $baseUrl, $slugs[ $source ] ?? '', $source );
 
-                foreach ( Settings::get_target_languages() as $language ) {
-                        if ( $language === $source ) {
-                                continue;
-                        }
+		foreach ( Settings::get_target_languages() as $language ) {
+			if ( $language === $source ) {
+						continue;
+			}
 
-                        if ( ! empty( $translations ) && empty( $translations[ $language ] ) ) {
-                                continue;
-                        }
+			if ( ! empty( $translations ) && empty( $translations[ $language ] ) ) {
+							continue;
+			}
 
-                        $languages[ $language ] = add_query_arg( 'fp_lang', $language, $baseUrl );
-                }
+							$languages[ $language ] = $this->build_language_url( $baseUrl, $slugs[ $language ] ?? '', $language );
+		}
 
-                return $languages;
-        }
+						return $languages;
+	}
 
-        private function resolve_base_url( $post ): string {
-                if ( $post instanceof \WP_Post ) {
-                        return get_permalink( $post );
-                }
+	private function build_language_url( string $baseUrl, string $slug, string $language ): string {
+		if ( $slug !== '' ) {
+				$localized = trailingslashit( home_url( $slug ) );
 
-                $requestUri = isset( $_SERVER['REQUEST_URI'] ) ? (string) $_SERVER['REQUEST_URI'] : '';
-                if ( $requestUri === '' ) {
-                        return home_url( '/' );
-                }
+				return $this->append_current_query_args( $localized );
+		}
 
-                $parts = explode( '?', $requestUri, 2 );
-                $path  = $parts[0];
+			$url = $this->append_current_query_args( $baseUrl );
 
-                if ( $path === '' ) {
-                        $path = '/';
-                } elseif ( $path[0] !== '/' ) {
-                        $path = '/' . $path;
-                }
+			return add_query_arg( 'fp_lang', $language, $url );
+	}
 
-                return home_url( $path );
-        }
+	private function resolve_base_url( ?WP_Post $post ): string {
+		if ( $post instanceof WP_Post ) {
+				return get_permalink( $post );
+		}
 
-        private function append_current_query_args( string $baseUrl ): string {
-                if ( empty( $_GET ) || ! is_array( $_GET ) ) {
-                        return $baseUrl;
-                }
+			$requestUri = isset( $_SERVER['REQUEST_URI'] ) ? (string) $_SERVER['REQUEST_URI'] : '';
+		if ( $requestUri === '' ) {
+			return home_url( '/' );
+		}
 
-                $queryArgs = array();
+			$parts = explode( '?', $requestUri, 2 );
+			$path  = $parts[0];
 
-                foreach ( wp_unslash( $_GET ) as $key => $value ) {
-                        if ( strtolower( (string) $key ) === 'fp_lang' ) {
-                                continue;
-                        }
+		if ( $path === '' ) {
+			$path = '/';
+		} elseif ( $path[0] !== '/' ) {
+			$path = '/' . $path;
+		}
 
-                        $queryArgs[ $key ] = $value;
-                }
+			return home_url( $path );
+	}
 
-                if ( empty( $queryArgs ) ) {
-                        return $baseUrl;
-                }
+	private function append_current_query_args( string $baseUrl ): string {
+		if ( empty( $_GET ) ) {
+				return $baseUrl;
+		}
 
-                return add_query_arg( $queryArgs, $baseUrl );
-        }
+			$queryArgs = array();
+
+		foreach ( wp_unslash( (array) $_GET ) as $key => $value ) {
+			if ( strtolower( (string) $key ) === 'fp_lang' ) {
+					continue;
+			}
+
+				$queryArgs[ $key ] = $value;
+		}
+
+		if ( empty( $queryArgs ) ) {
+			return $baseUrl;
+		}
+
+			return add_query_arg( $queryArgs, $baseUrl );
+	}
 }

--- a/fp-multilanguage/includes/autoload.php
+++ b/fp-multilanguage/includes/autoload.php
@@ -1,18 +1,18 @@
 <?php
 
 spl_autoload_register(
-        static function ( string $class ): void {
-                $prefix = 'FPMultilanguage\\';
+	static function ( string $className ): void {
+		$prefix = 'FPMultilanguage\\';
 
-                if ( 0 !== strpos( $class, $prefix ) ) {
-                        return;
-                }
+		if ( 0 !== strpos( $className, $prefix ) ) {
+			return;
+		}
 
-                $relative_class = substr( $class, strlen( $prefix ) );
-                $file            = __DIR__ . '/' . str_replace( '\\', '/', $relative_class ) . '.php';
+		$relative_class = substr( $className, strlen( $prefix ) );
+		$file           = __DIR__ . '/' . str_replace( '\\', '/', $relative_class ) . '.php';
 
-                if ( is_readable( $file ) ) {
-                        require_once $file;
-                }
-        }
+		if ( is_readable( $file ) ) {
+			require_once $file;
+		}
+	}
 );

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -121,21 +121,6 @@ parameters:
 			path: fp-multilanguage/includes/Dynamic/DynamicStrings.php
 
 		-
-			message: "#^Callback expects 1 parameter, \\$accepted_args is set to 4\\.$#"
-			count: 1
-			path: fp-multilanguage/includes/Dynamic/DynamicStrings.php
-
-		-
-			message: "#^Callback expects 4 parameters, \\$accepted_args is set to 5\\.$#"
-			count: 1
-			path: fp-multilanguage/includes/Dynamic/DynamicStrings.php
-
-		-
-			message: "#^Method FPMultilanguage\\\\Dynamic\\\\DynamicStrings\\:\\:filter_generic_string\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: fp-multilanguage/includes/Dynamic/DynamicStrings.php
-
-		-
 			message: "#^Method FPMultilanguage\\\\Dynamic\\\\DynamicStrings\\:\\:filter_generic_string\\(\\) has parameter \\$value with no type specified\\.$#"
 			count: 1
 			path: fp-multilanguage/includes/Dynamic/DynamicStrings.php
@@ -239,41 +224,6 @@ parameters:
 			message: "#^Template type T of method FPMultilanguage\\\\Support\\\\Container\\:\\:get\\(\\) is not referenced in a parameter\\.$#"
 			count: 1
 			path: fp-multilanguage/includes/Support/Container.php
-
-		-
-			message: "#^Class FPMultilanguage\\\\Widgets\\\\LanguageSwitcher extends generic class WP_Widget but does not specify its types\\: T$#"
-			count: 1
-			path: fp-multilanguage/includes/Widgets/LanguageSwitcher.php
-
-		-
-			message: "#^Function fp_multilanguage not found\\.$#"
-			count: 1
-			path: fp-multilanguage/includes/Widgets/LanguageSwitcher.php
-
-		-
-			message: "#^Offset 'after_title' on array\\{name\\: string, id\\: string, description\\: string, class\\: string, before_widget\\: string, after_widget\\: string, before_title\\: string, after_title\\: string, \\.\\.\\.\\} on left side of \\?\\? always exists and is not nullable\\.$#"
-			count: 1
-			path: fp-multilanguage/includes/Widgets/LanguageSwitcher.php
-
-		-
-			message: "#^Offset 'after_widget' on array\\{name\\: string, id\\: string, description\\: string, class\\: string, before_widget\\: string, after_widget\\: string, before_title\\: string, after_title\\: string, \\.\\.\\.\\} on left side of \\?\\? always exists and is not nullable\\.$#"
-			count: 1
-			path: fp-multilanguage/includes/Widgets/LanguageSwitcher.php
-
-		-
-			message: "#^Offset 'before_title' on array\\{name\\: string, id\\: string, description\\: string, class\\: string, before_widget\\: string, after_widget\\: string, before_title\\: string, after_title\\: string, \\.\\.\\.\\} on left side of \\?\\? always exists and is not nullable\\.$#"
-			count: 1
-			path: fp-multilanguage/includes/Widgets/LanguageSwitcher.php
-
-		-
-			message: "#^Offset 'before_widget' on array\\{name\\: string, id\\: string, description\\: string, class\\: string, before_widget\\: string, after_widget\\: string, before_title\\: string, after_title\\: string, \\.\\.\\.\\} on left side of \\?\\? always exists and is not nullable\\.$#"
-			count: 1
-			path: fp-multilanguage/includes/Widgets/LanguageSwitcher.php
-
-		-
-			message: "#^Property FPMultilanguage\\\\Widgets\\\\LanguageSwitcher\\:\\:\\$settings is never read, only written\\.$#"
-			count: 1
-			path: fp-multilanguage/includes/Widgets/LanguageSwitcher.php
 
 		-
 			message: "#^Function FPMultilanguage\\\\Content\\\\get_post\\(\\) has no return type specified\\.$#"

--- a/tests/LanguageSwitcherTest.php
+++ b/tests/LanguageSwitcherTest.php
@@ -1,9 +1,14 @@
 <?php
 namespace {
     if (! class_exists('WP_Post')) {
+        #[\AllowDynamicProperties]
         class WP_Post
         {
-            public $ID;
+            public int $ID = 0;
+            public string $post_title = '';
+            public string $post_content = '';
+            public string $post_excerpt = '';
+            public string $post_type = 'post';
 
             public function __construct(array $data = [])
             {
@@ -17,7 +22,7 @@ namespace {
     if (! class_exists('WP_Widget')) {
         class WP_Widget
         {
-            public function __construct($id_base = '', $name = '', $widget_options = [], $control_options = [])
+            public function __construct(string $id_base = '', string $name = '', array $widget_options = [], array $control_options = [])
             {
                 unset($id_base, $name, $widget_options, $control_options);
             }
@@ -35,7 +40,7 @@ namespace {
 
 namespace FPMultilanguage\Widgets {
     if (! function_exists(__NAMESPACE__ . '\\fpml_set_test_queried_object')) {
-        function fpml_set_test_queried_object($object): void
+        function fpml_set_test_queried_object(?object $object): void
         {
             $GLOBALS['fpml_test_queried_object'] = $object;
         }
@@ -50,7 +55,7 @@ namespace FPMultilanguage\Widgets {
     }
 
     if (! function_exists(__NAMESPACE__ . '\\get_queried_object')) {
-        function get_queried_object()
+        function get_queried_object(): ?object
         {
             return $GLOBALS['fpml_test_queried_object'] ?? null;
         }
@@ -68,17 +73,17 @@ namespace FPMultilanguage\Widgets {
     }
 
     if (! function_exists(__NAMESPACE__ . '\\fp_multilanguage')) {
-        function fp_multilanguage()
+        function fp_multilanguage(): object
         {
             return new class() {
-                public function get_container()
+                public function get_container(): object
                 {
                     return new class() {
-                        public function get($id)
+                        public function get(string $id): ?object
                         {
                             if ($id === 'post_translation_manager') {
                                 return new class() {
-                                    public function get_post_translations($postId)
+                                    public function get_post_translations(int $postId): array
                                     {
                                         return $GLOBALS['fpml_test_translations'][$postId] ?? [];
                                     }
@@ -116,6 +121,7 @@ class LanguageSwitcherTest extends TestCase
 
         $_GET = [];
         $_SERVER['REQUEST_URI'] = '/';
+        update_option('fp_multilanguage_slug_index', ['by_path' => [], 'by_post' => []]);
     }
 
     protected function tearDown(): void
@@ -124,6 +130,7 @@ class LanguageSwitcherTest extends TestCase
 
         $_GET = [];
         unset($_SERVER['REQUEST_URI']);
+        update_option('fp_multilanguage_slug_index', ['by_path' => [], 'by_post' => []]);
 
         parent::tearDown();
     }
@@ -161,6 +168,34 @@ class LanguageSwitcherTest extends TestCase
 
         $this->assertSame('https://example.com/category/news/?paged=2&fp_lang=en', $languages['en']);
         $this->assertSame('https://example.com/category/news/?paged=2&fp_lang=it', $languages['it']);
+    }
+
+    public function test_uses_seo_slugs_when_available(): void
+    {
+        $post = new \WP_Post(['ID' => 7]);
+        \FPMultilanguage\Widgets\fpml_set_test_queried_object($post);
+        \FPMultilanguage\Widgets\fpml_set_post_translations(7, [
+            'it' => ['content' => 'tradotto'],
+        ]);
+
+        update_option('fp_multilanguage_slug_index', [
+            'by_path' => [
+                'en/product' => ['post_id' => 7, 'language' => 'en'],
+                'it/prodotto' => ['post_id' => 7, 'language' => 'it'],
+            ],
+            'by_post' => [
+                7 => [
+                    'en' => 'en/product',
+                    'it' => 'it/prodotto',
+                ],
+            ],
+        ]);
+
+        $switcher = new LanguageSwitcher();
+        $languages = $this->invokeGetLanguages($switcher);
+
+        $this->assertSame('https://example.com/en/product/', $languages['en']);
+        $this->assertSame('https://example.com/it/prodotto/', $languages['it']);
     }
 
     private function invokeGetLanguages(LanguageSwitcher $switcher): array

--- a/tests/PostTranslationManagerTest.php
+++ b/tests/PostTranslationManagerTest.php
@@ -149,6 +149,62 @@ class PostTranslationManagerTest extends TestCase
         $this->assertSame('google:Original content', $translations['it']['content']);
         $this->assertSame('google:Original excerpt', $translations['it']['excerpt']);
         $this->assertArrayHasKey('updated_at', $translations['it']);
+        $this->assertArrayHasKey('source', $translations['it']);
+        $expectedSource = [
+            'title' => hash('sha1', 'Original title'),
+            'content' => hash('sha1', 'Original content'),
+            'excerpt' => hash('sha1', 'Original excerpt'),
+            'meta' => [],
+        ];
+        $this->assertSame($expectedSource, $translations['it']['source']);
+        $this->assertSame('synced', $translations['it']['status'] ?? null);
+    }
+
+    public function test_translate_post_does_not_duplicate_work_when_source_is_unchanged(): void
+    {
+        $postId = 101;
+        $post = new \WP_Post([
+            'ID' => $postId,
+            'post_title' => 'Stable title',
+            'post_content' => 'Stable content',
+            'post_excerpt' => 'Stable excerpt',
+        ]);
+        global $fp_test_posts;
+        $fp_test_posts[$postId] = $post;
+
+        $manager = new PostTranslationManager($this->service, $this->settings, $this->notices, $this->logger);
+        $firstTranslations = $manager->translate_post($postId);
+        $initialTimestamp = $firstTranslations['it']['updated_at'] ?? 0;
+
+        $secondTranslations = $manager->translate_post($postId);
+        $this->assertSame($firstTranslations, $secondTranslations, 'Le traduzioni non devono cambiare se il contenuto è invariato');
+        $this->assertSame($initialTimestamp, $secondTranslations['it']['updated_at'] ?? 0, 'Il timestamp deve rimanere identico quando non ci sono modifiche.');
+    }
+
+    public function test_translate_post_updates_only_changed_fields(): void
+    {
+        $postId = 202;
+        $post = new \WP_Post([
+            'ID' => $postId,
+            'post_title' => 'Title A',
+            'post_content' => 'Content A',
+            'post_excerpt' => 'Excerpt A',
+        ]);
+        global $fp_test_posts;
+        $fp_test_posts[$postId] = $post;
+
+        $manager = new PostTranslationManager($this->service, $this->settings, $this->notices, $this->logger);
+        $manager->translate_post($postId);
+
+        sleep(1);
+        $fp_test_posts[$postId]->post_title = 'Title B';
+
+        $translations = $manager->translate_post($postId);
+        $this->assertSame('google:Title B', $translations['it']['title']);
+        $this->assertSame('google:Content A', $translations['it']['content']);
+        $this->assertSame(hash('sha1', 'Title B'), $translations['it']['source']['title']);
+        $this->assertSame(hash('sha1', 'Content A'), $translations['it']['source']['content']);
+        $this->assertSame(hash('sha1', 'Excerpt A'), $translations['it']['source']['excerpt']);
     }
 
     public function test_handle_post_save_skips_translation_when_auto_translate_disabled(): void

--- a/tests/SEOTest.php
+++ b/tests/SEOTest.php
@@ -1,9 +1,14 @@
 <?php
 namespace {
     if (! class_exists('WP_Post')) {
+        #[\AllowDynamicProperties]
         class WP_Post
         {
-            public $ID;
+            public int $ID = 0;
+            public string $post_title = '';
+            public string $post_content = '';
+            public string $post_excerpt = '';
+            public string $post_type = 'post';
 
             public function __construct(array $data = [])
             {
@@ -31,12 +36,22 @@ class SEOTest extends TestCase
     {
         parent::setUp();
 
-        global $wp_test_options, $wp_test_filters, $wp_test_actions;
+        global $wp_test_options, $wp_test_filters, $wp_test_actions, $wp_test_post_meta;
         $wp_test_options = [];
         $wp_test_filters = [];
         $wp_test_actions = [];
+        $wp_test_post_meta = [];
 
         Settings::bootstrap_defaults();
+        update_option('fp_multilanguage_slug_index', ['by_path' => [], 'by_post' => []]);
+    }
+
+    protected function tearDown(): void
+    {
+        unset($_POST['fp_multilanguage_seo'], $_POST['fp_multilanguage_seo_nonce']);
+        unset($_SERVER['REQUEST_URI']);
+
+        parent::tearDown();
     }
 
     public function test_filter_sitemap_entry_adds_hreflang_links(): void
@@ -125,6 +140,45 @@ class SEOTest extends TestCase
         );
 
         $this->assertSame($expectedAlternates, $resolvedLinks);
+    }
+
+    public function test_resolve_slug_request_maps_to_original_post(): void
+    {
+        $logger = new Logger();
+        $notices = new AdminNotices($logger);
+        $settings = new Settings($logger, $notices);
+        $translationService = new TranslationService($logger, $notices, $settings);
+        $manager = $this->createMock(PostTranslationManager::class);
+        $manager->method('get_post_translations')->willReturn([
+            'it' => ['content' => 'test'],
+        ]);
+
+        $seo = new SEO($settings, $translationService, $manager, $logger);
+
+        $postId = 55;
+        $post = new \WP_Post(['ID' => $postId]);
+        $_POST['fp_multilanguage_seo_nonce'] = wp_create_nonce('fp_multilanguage_seo_meta');
+        $_POST['fp_multilanguage_seo'] = [
+            'slug' => [
+                'en' => 'en/product',
+                'it' => 'it/prodotto',
+            ],
+        ];
+
+        $seo->save_meta($postId, $post);
+
+        $slugs = SEO::get_language_slugs($postId);
+        $this->assertSame([
+            'en' => 'en/product',
+            'it' => 'it/prodotto',
+        ], $slugs);
+
+        $_SERVER['REQUEST_URI'] = '/it/prodotto/';
+        $query = $seo->resolve_slug_request([]);
+
+        $this->assertSame(55, $query['p']);
+        $this->assertSame(55, $query['page_id']);
+        $this->assertSame('it', $query['fp_lang']);
     }
 
     /**

--- a/tests/stubs/wordpress.php
+++ b/tests/stubs/wordpress.php
@@ -36,6 +36,11 @@ if (! isset($wp_test_actions)) {
     $wp_test_actions = [];
 }
 
+global $wp_test_post_meta;
+if (! isset($wp_test_post_meta)) {
+    $wp_test_post_meta = [];
+}
+
 global $wp_test_textdomains;
 if (! isset($wp_test_textdomains)) {
     $wp_test_textdomains = [];
@@ -614,13 +619,37 @@ if (! function_exists('get_query_var')) {
 if (! function_exists('get_post_meta')) {
     function get_post_meta($post_id, $key = '', $single = false)
     {
-        return [];
+        global $wp_test_post_meta;
+
+        if (! isset($wp_test_post_meta[$post_id])) {
+            return $single ? '' : [];
+        }
+
+        if ($key === '') {
+            return $single ? $wp_test_post_meta[$post_id] : [$wp_test_post_meta[$post_id]];
+        }
+
+        if (! array_key_exists($key, $wp_test_post_meta[$post_id])) {
+            return $single ? '' : [];
+        }
+
+        $value = $wp_test_post_meta[$post_id][$key];
+
+        return $single ? $value : [$value];
     }
 }
 
 if (! function_exists('update_post_meta')) {
     function update_post_meta($post_id, $key, $value)
     {
+        global $wp_test_post_meta;
+
+        if (! isset($wp_test_post_meta[$post_id])) {
+            $wp_test_post_meta[$post_id] = [];
+        }
+
+        $wp_test_post_meta[$post_id][$key] = $value;
+
         return true;
     }
 }


### PR DESCRIPTION
## Summary
- add source hashing and meta-sync helpers to `PostTranslationManager` so translations only refresh when content actually changes and stored meta stays consistent
- index SEO slugs, resolve friendly URLs to the right language/post pair, and teach the language switcher to reuse those slugs instead of falling back to query args
- surface live translation quota usage in the settings UI, initialise defaults on activation, and clear slug indexes during uninstall

## Testing
- composer lint
- composer stan
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d2beb17680832f94079fdd8ac02068