### PR TITLE
Expose translation quota metrics across plugin

### DIFF
--- a/fp-multilanguage/includes/Admin/Settings.php
+++ b/fp-multilanguage/includes/Admin/Settings.php
@@ -194,14 +194,15 @@ class Settings {
 				return new WP_Error( 'invalid_payload', $message, array( 'status' => 400 ) );
 		}
 
-			$options = $this->sanitize( $params );
-			update_option( self::OPTION_NAME, $options );
-			TranslationService::flush_cache();
+		$options = $this->sanitize( $params );
+		update_option( self::OPTION_NAME, $options );
+		TranslationService::flush_cache();
 
-			$this->logger->info( 'Settings updated via REST API.' );
-			$this->notices->add_notice( __( 'Impostazioni aggiornate correttamente.', 'fp-multilanguage' ) );
+		$options = $this->get_options();
+		$this->logger->info( 'Settings updated via REST API.' );
+		$this->notices->add_notice( __( 'Impostazioni aggiornate correttamente.', 'fp-multilanguage' ) );
 
-			return rest_ensure_response( $options );
+		return rest_ensure_response( $options );
 	}
 
 	public function enqueue_assets( string $hook ): void {
@@ -419,14 +420,13 @@ class Settings {
 			}
 		}
 
-		if ( ! isset( $sanitized['quote_tracking'] ) || ! is_array( $sanitized['quote_tracking'] ) ) {
-			$sanitized['quote_tracking'] = array();
-		}
+		$sanitized['quote_tracking'] = self::get_quote_tracking();
 
 		TranslationService::flush_cache();
 
 		return $sanitized;
 	}
+
 
 	private function sanitize_language( string $value ): string {
 		$value = sanitize_text_field( strtolower( $value ) );
@@ -439,15 +439,23 @@ class Settings {
 			return self::$defaults;
 		}
 
-		$options = get_option( self::OPTION_NAME, array() );
+		$optionsRaw = get_option( self::OPTION_NAME, array() );
 
-		return wp_parse_args( is_array( $options ) ? $options : array(), self::$defaults );
+		$options = wp_parse_args( is_array( $optionsRaw ) ? $optionsRaw : array(), self::$defaults );
+
+		$options['quote_tracking'] = self::get_quote_tracking();
+
+		return $options;
 	}
 
 	public static function get_manual_strings(): array {
 		$stored = get_option( self::MANUAL_STRINGS_OPTION, array() );
 
 		return is_array( $stored ) ? $stored : array();
+	}
+
+	public static function get_quote_tracking(): array {
+		return TranslationService::get_usage_stats();
 	}
 
 	public static function update_manual_string( string $key, string $language, string $value ): void {

--- a/fp-multilanguage/includes/Plugin.php
+++ b/fp-multilanguage/includes/Plugin.php
@@ -127,6 +127,8 @@ class Plugin {
 		$migrator = $instance->container->get( 'migrator' );
 		$migrator->maybe_migrate();
 
+		Settings::bootstrap_defaults();
+
 		update_option( self::VERSION_OPTION, FP_MULTILANGUAGE_VERSION );
 	}
 

--- a/fp-multilanguage/includes/Services/TranslationService.php
+++ b/fp-multilanguage/includes/Services/TranslationService.php
@@ -133,6 +133,41 @@ class TranslationService {
 	}
 
 	/**
+	 * @return array<string, array<string, array{requests:int,characters:int,updated_at:int}>>
+	 */
+	public static function get_usage_stats(): array {
+		if ( ! function_exists( 'get_option' ) ) {
+			return array();
+		}
+
+		$stored = get_option( self::QUOTA_OPTION, array() );
+		if ( ! is_array( $stored ) ) {
+			return array();
+		}
+
+		$normalized = array();
+		foreach ( $stored as $provider => $languages ) {
+			if ( ! is_array( $languages ) ) {
+				continue;
+			}
+
+			foreach ( $languages as $language => $usage ) {
+				if ( ! is_array( $usage ) ) {
+					continue;
+				}
+
+				$normalized[ $provider ][ $language ] = array(
+					'requests'   => (int) ( $usage['requests'] ?? 0 ),
+					'characters' => (int) ( $usage['characters'] ?? 0 ),
+					'updated_at' => isset( $usage['updated_at'] ) ? (int) $usage['updated_at'] : 0,
+				);
+			}
+		}
+
+		return $normalized;
+	}
+
+	/**
 	 * @param array<string, mixed> $options
 	 */
 	private function normalize_options( array $options ): array {
@@ -359,12 +394,7 @@ class TranslationService {
 	 * @return array<string, array<string, array{requests:int,characters:int,updated_at:int}>>
 	 */
 	private function get_quota(): array {
-		$stored = get_option( self::QUOTA_OPTION, array() );
-		if ( ! is_array( $stored ) ) {
-			return array();
-		}
-
-		return $stored;
+		return self::get_usage_stats();
 	}
 
 	protected function get_text_length( string $text ): int {

--- a/tests/TranslationServiceTest.php
+++ b/tests/TranslationServiceTest.php
@@ -210,11 +210,33 @@ class TranslationServiceTest extends TestCase
             'quote_tracking' => [],
         ]);
 
-        TranslationService::flush_cache();
+		TranslationService::flush_cache();
 
-        $deeplHtml = '<div>Altro <em>contenuto</em> di prova</div>';
-        $deeplTranslation = $this->service->translate_text($deeplHtml, 'en', 'it', ['format' => 'html']);
+		$deeplHtml = '<div>Altro <em>contenuto</em> di prova</div>';
+		$deeplTranslation = $this->service->translate_text($deeplHtml, 'en', 'it', ['format' => 'html']);
 
-        $this->assertSame('deepl:' . $deeplHtml, $deeplTranslation, 'DeepL deve mantenere i tag HTML quando richiesto.');
-    }
+		$this->assertSame('deepl:' . $deeplHtml, $deeplTranslation, 'DeepL deve mantenere i tag HTML quando richiesto.');
+	}
+
+	public function test_exposes_quota_usage_stats(): void
+	{
+		$this->service->translate_text('Quota check', 'en', 'it');
+
+		$usage = TranslationService::get_usage_stats();
+
+		$this->assertArrayHasKey('google', $usage, 'Il provider Google deve essere tracciato nelle quote.');
+		$this->assertArrayHasKey('it', $usage['google'], 'La lingua di destinazione deve essere registrata.');
+		$this->assertSame(1, $usage['google']['it']['requests'], 'Il numero di richieste deve essere incrementato.');
+		$this->assertSame(strlen('Quota check'), $usage['google']['it']['characters'], 'I caratteri utilizzati devono essere conteggiati.');
+		$this->assertGreaterThan(0, $usage['google']['it']['updated_at'], 'La data di aggiornamento deve essere valorizzata.');
+	}
+
+	public function test_settings_include_quote_tracking_usage(): void
+	{
+		$this->service->translate_text('Settings quota', 'en', 'it');
+
+		$options = Settings::get_options();
+
+		$this->assertSame(1, $options['quote_tracking']['google']['it']['requests'] ?? 0, 'Le impostazioni devono esporre la quota aggregata.');
+	}
 }


### PR DESCRIPTION
## Summary
- surface translation usage via a new TranslationService::get_usage_stats helper and reuse it for quota reads
- keep settings REST responses and UI in sync by deriving quote tracking data and bootstrapping defaults on activation
- extend the translation service test suite to cover the new usage API and settings integration

## Testing
- composer qa

------
https://chatgpt.com/codex/tasks/task_e_68d42a00cfa8832fb5e4f3f93b4fe622