### PR TITLE
Improve resilience to invalid translation provider responses

### DIFF
--- a/fp-multilanguage/includes/Services/Providers/DeepLProvider.php
+++ b/fp-multilanguage/includes/Services/Providers/DeepLProvider.php
@@ -69,12 +69,32 @@ class DeepLProvider implements TranslationProviderInterface {
 			return null;
 		}
 
-		$payload    = json_decode( wp_remote_retrieve_body( $response ), true );
-		$translated = $payload['translations'][0]['text'] ?? '';
-		if ( $translated === '' ) {
-			return null;
+				$body = wp_remote_retrieve_body( $response );
+		if ( ! is_string( $body ) || $body === '' ) {
+				$this->logger->warning( 'DeepL empty body response' );
+
+				return null;
 		}
 
-		return new TranslationResponse( (string) $translated, true, array( 'provider' => $this->get_name() ) );
+				$payload = json_decode( $body, true );
+		if ( ! is_array( $payload ) ) {
+				$this->logger->warning( 'DeepL invalid JSON response' );
+
+				return null;
+		}
+
+				$translations = $payload['translations'] ?? array();
+		if ( ! is_array( $translations ) || ! isset( $translations[0]['text'] ) ) {
+				$this->logger->warning( 'DeepL missing text field' );
+
+				return null;
+		}
+
+				$translated = (string) $translations[0]['text'];
+		if ( $translated === '' ) {
+				return null;
+		}
+
+				return new TranslationResponse( $translated, true, array( 'provider' => $this->get_name() ) );
 	}
 }

--- a/fp-multilanguage/includes/Services/Providers/GoogleProvider.php
+++ b/fp-multilanguage/includes/Services/Providers/GoogleProvider.php
@@ -59,12 +59,32 @@ class GoogleProvider implements TranslationProviderInterface {
 			return null;
 		}
 
-		$payload    = json_decode( wp_remote_retrieve_body( $response ), true );
-		$translated = $payload['data']['translations'][0]['translatedText'] ?? '';
-		if ( $translated === '' ) {
-			return null;
+				$body = wp_remote_retrieve_body( $response );
+		if ( ! is_string( $body ) || $body === '' ) {
+				$this->logger->warning( 'Google Translate empty body response' );
+
+				return null;
 		}
 
-		return new TranslationResponse( (string) $translated, true, array( 'provider' => $this->get_name() ) );
+				$payload = json_decode( $body, true );
+		if ( ! is_array( $payload ) ) {
+				$this->logger->warning( 'Google Translate invalid JSON response' );
+
+				return null;
+		}
+
+				$translations = $payload['data']['translations'] ?? array();
+		if ( ! is_array( $translations ) || ! isset( $translations[0]['translatedText'] ) ) {
+				$this->logger->warning( 'Google Translate missing translatedText field' );
+
+				return null;
+		}
+
+				$translated = (string) $translations[0]['translatedText'];
+		if ( $translated === '' ) {
+				return null;
+		}
+
+				return new TranslationResponse( $translated, true, array( 'provider' => $this->get_name() ) );
 	}
 }

--- a/tests/TranslationServiceTest.php
+++ b/tests/TranslationServiceTest.php
@@ -22,13 +22,14 @@ class TranslationServiceTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        global $wp_test_options, $wp_test_cache, $wp_test_transients, $wp_remote_post_calls, $wp_test_filters, $wp_remote_post_failures, $wp_test_actions, $wp_test_textdomains;
+        global $wp_test_options, $wp_test_cache, $wp_test_transients, $wp_remote_post_calls, $wp_test_filters, $wp_remote_post_failures, $wp_remote_post_invalid_json, $wp_test_actions, $wp_test_textdomains;
         $wp_test_options = [];
         $wp_test_cache = [];
         $wp_test_transients = [];
         $wp_remote_post_calls = [];
         $wp_test_filters = [];
         $wp_remote_post_failures = [];
+        $wp_remote_post_invalid_json = [];
         $wp_test_actions = [];
         $wp_test_textdomains = [];
 
@@ -106,6 +107,17 @@ class TranslationServiceTest extends TestCase
         $result = $this->service->translate_text('Test string', 'en', 'it');
 
         $this->assertSame('deepl:Test string', $result);
+    }
+
+    public function test_uses_fallback_provider_when_json_response_is_invalid(): void
+    {
+        global $wp_remote_post_invalid_json;
+        $wp_remote_post_invalid_json['translation.googleapis.com'] = 3;
+
+        TranslationService::flush_cache();
+        $result = $this->service->translate_text('Trigger invalid JSON', 'en', 'it');
+
+        $this->assertSame('deepl:Trigger invalid JSON', $result, 'Il servizio deve passare al provider successivo quando la risposta JSON è non valida.');
     }
 
     public function test_manual_translation_is_returned_when_available(): void

--- a/tests/stubs/wordpress.php
+++ b/tests/stubs/wordpress.php
@@ -26,6 +26,11 @@ if (! isset($wp_remote_post_failures)) {
     $wp_remote_post_failures = [];
 }
 
+global $wp_remote_post_invalid_json;
+if (! isset($wp_remote_post_invalid_json)) {
+    $wp_remote_post_invalid_json = [];
+}
+
 global $wp_test_filters;
 if (! isset($wp_test_filters)) {
     $wp_test_filters = [];
@@ -189,7 +194,7 @@ if (! function_exists('wp_json_encode')) {
 if (! function_exists('wp_remote_post')) {
     function wp_remote_post($url, $args = [])
     {
-        global $wp_remote_post_calls, $wp_remote_post_failures;
+        global $wp_remote_post_calls, $wp_remote_post_failures, $wp_remote_post_invalid_json;
         $host = parse_url($url, PHP_URL_HOST) ?: $url;
         if (! isset($wp_remote_post_calls[$host])) {
             $wp_remote_post_calls[$host] = 0;
@@ -205,6 +210,18 @@ if (! function_exists('wp_remote_post')) {
             return [
                 'response' => ['code' => 500],
                 'body' => json_encode(['error' => 'Simulated failure']),
+            ];
+        }
+
+        if (isset($wp_remote_post_invalid_json[$host]) && $wp_remote_post_invalid_json[$host] > 0) {
+            $wp_remote_post_invalid_json[$host]--;
+            if ($wp_remote_post_invalid_json[$host] === 0) {
+                unset($wp_remote_post_invalid_json[$host]);
+            }
+
+            return [
+                'response' => ['code' => 200],
+                'body' => '{invalid-json-response',
             ];
         }
 


### PR DESCRIPTION
## Summary
- harden Google and DeepL translation providers against empty bodies or invalid JSON payloads and improve logging
- extend the WordPress stubs to simulate malformed API replies and reset state during tests
- add a regression test ensuring the service falls back to the next provider when a response cannot be parsed

## Testing
- composer lint
- composer stan
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d435255f7c832f93941319bf76b280