### PR TITLE
Normalize locale handling for multilingual detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ FP Multilanguage è un plugin WordPress enterprise-ready per orchestrare contenu
 ## Configurazione
 
 - Vai in **Impostazioni → FP Multilanguage** per definire lingua sorgente/fallback, lingue di destinazione, provider (Google/DeepL), SEO e monitor quote.
+- I codici lingua sono normalizzati automaticamente e supportano formati regionali (`pt-BR`, `es-ES`, `zh-Hant`).
 - Il bottone “Sincronizza via REST” usa `admin.js` per inviare le opzioni all’endpoint `fp-multilanguage/v1/settings` (nonce `fp_multilanguage_settings`).
 - Le traduzioni manuali delle stringhe sono gestite tramite AJAX (`wp_ajax_fp_multilanguage_save_string`) e REST (`fp-multilanguage/v1/strings`).
 

--- a/fp-multilanguage/includes/Admin/Settings.php
+++ b/fp-multilanguage/includes/Admin/Settings.php
@@ -1,6 +1,7 @@
 <?php
 namespace FPMultilanguage\Admin;
 
+use FPMultilanguage\CurrentLanguage;
 use FPMultilanguage\Services\Logger;
 use FPMultilanguage\Services\TranslationService;
 use WP_Error;
@@ -485,16 +486,23 @@ class Settings {
 
 			TranslationService::flush_cache();
 
-			self::set_cached_options( $sanitized );
+						self::set_cached_options( $sanitized );
+						CurrentLanguage::clear_cache();
 
 			return $sanitized;
 	}
 
 
 	private function sanitize_language( string $value ): string {
-		$value = sanitize_text_field( strtolower( $value ) );
+			$value = sanitize_text_field( strtolower( $value ) );
+			$value = str_replace( array( ' ', '_' ), '-', $value );
 
-		return preg_replace( '/[^a-z0-9_-]/', '', $value );
+			$value = preg_replace( '/[^a-z0-9-]/', '', $value );
+		if ( null === $value ) {
+				return '';
+		}
+
+			return trim( $value, '-' );
 	}
 
 	public static function get_options(): array {

--- a/fp-multilanguage/includes/CurrentLanguage.php
+++ b/fp-multilanguage/includes/CurrentLanguage.php
@@ -9,126 +9,196 @@ class CurrentLanguage {
 
 	public static function resolve(): string {
 		if ( self::$cached !== null ) {
-			return self::$cached;
+				return self::$cached;
 		}
 
-		$language = self::detect_from_query();
-		$source   = Settings::get_source_language();
+			$source = self::normalize_language_code( Settings::get_source_language() );
 
-		if ( $language === '' ) {
-			$language = self::detect_from_cookie();
+			$allowedLanguages = array_merge(
+				array( $source ),
+				Settings::get_target_languages()
+			);
+			$allowedLanguages = array_values(
+				array_unique(
+					array_filter(
+						array_map( array( self::class, 'normalize_language_code' ), $allowedLanguages )
+					)
+				)
+			);
+
+			$language = self::match_allowed_language( self::detect_from_query(), $allowedLanguages );
+
+		if ( '' === $language ) {
+				$language = self::match_allowed_language( self::detect_from_cookie(), $allowedLanguages );
 		}
 
-		if ( $language === '' && function_exists( 'wp_get_current_user' ) ) {
-			$user = wp_get_current_user();
+		if ( '' === $language && function_exists( 'wp_get_current_user' ) ) {
+				$user = wp_get_current_user();
 			if ( $user && isset( $user->ID ) && $user->ID > 0 ) {
-				$userLanguage = get_user_meta( $user->ID, 'fp_multilanguage_language', true );
-				if ( is_string( $userLanguage ) && $userLanguage !== '' ) {
-					$language = $userLanguage;
+					$userLanguage = get_user_meta( $user->ID, 'fp_multilanguage_language', true );
+				if ( is_string( $userLanguage ) ) {
+					$language = self::match_allowed_language( $userLanguage, $allowedLanguages );
 				}
 			}
 		}
 
-		if ( $language === '' && function_exists( 'determine_locale' ) ) {
-			$locale = determine_locale();
+		if ( '' === $language && function_exists( 'determine_locale' ) ) {
+				$locale = determine_locale();
 			if ( is_string( $locale ) && $locale !== '' ) {
-				$language = substr( $locale, 0, 2 );
+					$candidate = self::normalize_language_code( $locale );
+					$language  = self::match_allowed_language( $candidate, $allowedLanguages );
+
+				if ( '' === $language ) {
+					$language = $candidate;
+				}
 			}
 		}
 
-		if ( $language === '' && isset( $_SERVER['REQUEST_URI'] ) ) {
-			$uriLanguage = self::detect_from_path( (string) $_SERVER['REQUEST_URI'] );
-			if ( $uriLanguage !== '' ) {
-				$language = $uriLanguage;
+		if ( '' === $language && isset( $_SERVER['REQUEST_URI'] ) ) {
+				$candidate = self::detect_from_path( (string) $_SERVER['REQUEST_URI'] );
+			if ( $candidate !== '' ) {
+					$language = self::match_allowed_language( $candidate, $allowedLanguages );
+
+				if ( '' === $language ) {
+					$language = $candidate;
+				}
 			}
 		}
-
-		$language = strtolower( $language );
 
 		if ( function_exists( 'apply_filters' ) ) {
-			$language = (string) apply_filters(
-				'fp_multilanguage_current_language',
-				$language,
-				array(
-					'source' => $source,
-				)
-			);
+				$language = (string) apply_filters(
+					'fp_multilanguage_current_language',
+					$language,
+					array(
+						'source' => $source,
+					)
+				);
 		}
 
-		if ( $language === '' ) {
-			$language = $source;
+			$language = self::match_allowed_language( $language, $allowedLanguages );
+
+		if ( '' === $language ) {
+				$language = $source;
 		}
 
-		self::$cached = strtolower( $language );
+			self::$cached = $language;
 
-		return self::$cached;
+			return self::$cached;
 	}
 
 	public static function remember( string $language ): void {
-		$language = strtolower( $language );
+			$language = self::normalize_language_code( $language );
 		if ( $language === '' ) {
-			return;
+				return;
 		}
 
-		$cookiePath   = defined( 'COOKIEPATH' ) ? COOKIEPATH : '/';
-		$cookieDomain = defined( 'COOKIE_DOMAIN' ) ? COOKIE_DOMAIN : ''; // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound
-		$secure       = function_exists( 'is_ssl' ) ? is_ssl() : false;
-		$httpOnly     = true;
-		$expire       = time() + ( defined( 'YEAR_IN_SECONDS' ) ? YEAR_IN_SECONDS : 31536000 );
+			$cookiePath   = defined( 'COOKIEPATH' ) ? COOKIEPATH : '/';
+			$cookieDomain = defined( 'COOKIE_DOMAIN' ) ? COOKIE_DOMAIN : ''; // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound
+			$secure       = function_exists( 'is_ssl' ) ? is_ssl() : false;
+			$httpOnly     = true;
+			$expire       = time() + ( defined( 'YEAR_IN_SECONDS' ) ? YEAR_IN_SECONDS : 31536000 );
 
 		if ( function_exists( 'setcookie' ) ) {
-				setcookie( 'fp_multilanguage_lang', $language, $expire, $cookiePath, $cookieDomain, $secure, $httpOnly );
+			setcookie( 'fp_multilanguage_lang', $language, $expire, $cookiePath, $cookieDomain, $secure, $httpOnly );
 		}
 
-				$_COOKIE['fp_multilanguage_lang'] = $language; // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
+			$_COOKIE['fp_multilanguage_lang'] = $language; // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
 
 		if ( function_exists( 'wp_get_current_user' ) ) {
-				$user = wp_get_current_user();
+			$user = wp_get_current_user();
 			if ( $user && isset( $user->ID ) && $user->ID > 0 ) {
-						update_user_meta( $user->ID, 'fp_multilanguage_language', $language );
+					update_user_meta( $user->ID, 'fp_multilanguage_language', $language );
 			}
 		}
 
-		self::$cached = $language;
+			self::$cached = $language;
+	}
+
+	public static function clear_cache(): void {
+			self::$cached = null;
 	}
 
 	private static function detect_from_query(): string {
 		if ( function_exists( 'get_query_var' ) ) {
-			$queryVar = (string) get_query_var( 'fp_lang' );
+				$queryVar = (string) get_query_var( 'fp_lang' );
 			if ( $queryVar !== '' ) {
-				return sanitize_key( $queryVar );
+				return self::normalize_language_code( $queryVar );
 			}
 		}
 
 		if ( isset( $_GET['fp_lang'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			return sanitize_key( (string) wp_unslash( $_GET['fp_lang'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+				return self::normalize_language_code( (string) wp_unslash( $_GET['fp_lang'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		}
 
-		return '';
+			return '';
 	}
 
 	private static function detect_from_cookie(): string {
 		if ( isset( $_COOKIE['fp_multilanguage_lang'] ) ) { // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
-			return sanitize_key( (string) $_COOKIE['fp_multilanguage_lang'] ); // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
+				return self::normalize_language_code( (string) $_COOKIE['fp_multilanguage_lang'] ); // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
 		}
 
-		return '';
+			return '';
 	}
 
 	private static function detect_from_path( string $path ): string {
-		$segments = array_filter( explode( '/', trim( $path, '/' ) ) );
+			$segments = array_filter( explode( '/', trim( $path, '/' ) ) );
 		if ( empty( $segments ) ) {
-			return '';
+				return '';
 		}
 
-		$first     = strtolower( (string) array_shift( $segments ) );
-		$targets   = Settings::get_target_languages();
-		$targets[] = Settings::get_source_language();
+			$first     = self::normalize_language_code( (string) array_shift( $segments ) );
+			$targets   = Settings::get_target_languages();
+			$targets[] = Settings::get_source_language();
+
+			$targets = array_map( array( self::class, 'normalize_language_code' ), $targets );
+
+			$targets = array_filter( $targets );
 
 		if ( in_array( $first, $targets, true ) ) {
-			return $first;
+				return $first;
 		}
 
-		return '';
+			return '';
+	}
+
+	private static function normalize_language_code( string $value ): string {
+			$value = strtolower( trim( $value ) );
+			$value = str_replace( array( ' ', '_' ), '-', $value );
+
+			$value = preg_replace( '/[^a-z0-9-]/', '', $value );
+		if ( null === $value ) {
+				return '';
+		}
+
+			$value = preg_replace( '/-+/', '-', $value );
+		if ( null === $value ) {
+				return '';
+		}
+
+			return trim( $value, '-' );
+	}
+
+	private static function match_allowed_language( string $language, array $allowed ): string {
+			$language = self::normalize_language_code( $language );
+		if ( '' === $language ) {
+				return '';
+		}
+
+		if ( in_array( $language, $allowed, true ) ) {
+				return $language;
+		}
+
+		if ( strpos( $language, '-' ) !== false ) {
+				$base = strstr( $language, '-', true );
+			if ( false !== $base ) {
+					$base = self::normalize_language_code( $base );
+				if ( in_array( $base, $allowed, true ) ) {
+					return $base;
+				}
+			}
+		}
+
+			return '';
 	}
 }

--- a/fp-multilanguage/includes/Plugin.php
+++ b/fp-multilanguage/includes/Plugin.php
@@ -126,14 +126,24 @@ class Plugin {
 			return;
 		}
 
-		$allowed_languages = array_merge(
-			array( Settings::get_source_language() ),
-			Settings::get_target_languages()
-		);
-		$allowed_languages = array_unique( array_map( 'strtolower', $allowed_languages ) );
+				$allowed_languages = array_merge(
+					array( Settings::get_source_language() ),
+					Settings::get_target_languages()
+				);
+				$allowed_languages = array_unique(
+					array_map(
+						static function ( string $language ): string {
+										$language = strtolower( $language );
+										$language = str_replace( array( ' ', '_' ), '-', $language );
+
+										return trim( preg_replace( '/[^a-z0-9-]/', '', $language ) ?? '', '-' );
+						},
+						$allowed_languages
+					)
+				);
 
 		if ( ! in_array( $language, $allowed_languages, true ) ) {
-			return;
+				return;
 		}
 
 		$remembered = '';

--- a/readme.txt
+++ b/readme.txt
@@ -26,6 +26,7 @@ FP Multilanguage offre:
 1. Carica la cartella `fp-multilanguage` in `wp-content/plugins/`.
 2. Attiva il plugin dalla schermata "Plugin" in WordPress.
 3. Configura le lingue e le chiavi API in Impostazioni → FP Multilanguage.
+4. Inserisci i codici lingua nel formato desiderato (ad es. `pt-BR`, `zh-Hant`): il plugin li normalizza automaticamente.
 
 == Frequently Asked Questions ==
 

--- a/tests/CurrentLanguageTest.php
+++ b/tests/CurrentLanguageTest.php
@@ -17,6 +17,10 @@ class CurrentLanguageTest extends TestCase
         $wp_test_options = [];
         $wp_test_actions = [];
         $wp_test_textdomains = [];
+        $GLOBALS['wp_test_locale'] = 'en_US';
+
+        global $wp_user_meta_storage;
+        $wp_user_meta_storage = [];
 
         $_GET = [];
         $_COOKIE = [];
@@ -33,6 +37,9 @@ class CurrentLanguageTest extends TestCase
         $_GET = [];
         $_COOKIE = [];
         unset($_SERVER['REQUEST_URI']);
+        $GLOBALS['wp_test_locale'] = 'en_US';
+
+        \FPMultilanguage\CurrentLanguage::clear_cache();
 
         parent::tearDown();
     }
@@ -50,6 +57,35 @@ class CurrentLanguageTest extends TestCase
         $this->assertSame('it', CurrentLanguage::resolve(), 'La lingua corrente deve corrispondere a quella memorizzata.');
     }
 
+    public function test_remember_normalizes_language_code(): void
+    {
+        CurrentLanguage::remember('PT_br');
+
+        $this->assertSame('pt-br', $_COOKIE['fp_multilanguage_lang'] ?? null);
+        $this->assertSame('pt-br', CurrentLanguage::resolve());
+        $this->assertSame('pt-br', get_user_meta(1, 'fp_multilanguage_language', true));
+    }
+
+    public function test_resolve_detects_regional_locale(): void
+    {
+        $GLOBALS['wp_test_locale'] = 'pt_BR';
+
+        update_option(Settings::OPTION_NAME, [
+            'source_language' => 'en',
+            'fallback_language' => 'en',
+            'target_languages' => ['pt-br'],
+            'providers' => [],
+            'seo' => [],
+            'quote_tracking' => [],
+            'auto_translate' => false,
+        ]);
+
+        Settings::clear_cache();
+        $this->resetCurrentLanguageCache();
+
+        $this->assertSame('pt-br', CurrentLanguage::resolve());
+    }
+
     private function resetPluginSingleton(): void
     {
         $reflection = new ReflectionClass(Plugin::class);
@@ -60,9 +96,6 @@ class CurrentLanguageTest extends TestCase
 
     private function resetCurrentLanguageCache(): void
     {
-        $reflection = new ReflectionClass(CurrentLanguage::class);
-        $property = $reflection->getProperty('cached');
-        $property->setAccessible(true);
-        $property->setValue(null, null);
+        CurrentLanguage::clear_cache();
     }
 }

--- a/tests/DynamicStringsTest.php
+++ b/tests/DynamicStringsTest.php
@@ -32,6 +32,7 @@ class DynamicStringsTest extends TestCase
         $_GET = [];
 
         Settings::bootstrap_defaults();
+        \FPMultilanguage\CurrentLanguage::clear_cache();
         $this->logger = new Logger();
         $this->notices = new AdminNotices($this->logger);
         $this->settings = new Settings($this->logger, $this->notices);

--- a/tests/PostTranslationManagerTest.php
+++ b/tests/PostTranslationManagerTest.php
@@ -118,6 +118,7 @@ class PostTranslationManagerTest extends TestCase
         $fp_test_posts = [];
 
         Settings::bootstrap_defaults();
+        \FPMultilanguage\CurrentLanguage::clear_cache();
         $options = Settings::get_options();
         $options['providers']['google']['enabled'] = true;
         $options['providers']['google']['api_key'] = 'unit-test-key';

--- a/tests/SettingsTest.php
+++ b/tests/SettingsTest.php
@@ -77,6 +77,22 @@ class SettingsTest extends TestCase
         $this->assertFalse( $sanitized['providers']['deepl']['enabled'], 'Il provider DeepL deve essere disabilitato senza chiave API.' );
     }
 
+    public function test_sanitize_normalizes_language_formats(): void
+    {
+        $input = array(
+            'source_language'   => 'EN',
+            'fallback_language' => 'PT_BR',
+            'target_languages'  => 'PT_BR, ES_es',
+        );
+
+        $sanitized = $this->settings->sanitize( $input );
+
+        $this->assertSame( 'en', $sanitized['source_language'] );
+        $this->assertSame( 'pt-br', $sanitized['fallback_language'] );
+        $this->assertContains( 'pt-br', $sanitized['target_languages'] );
+        $this->assertContains( 'es-es', $sanitized['target_languages'] );
+    }
+
     public function test_get_options_uses_cache_until_cleared(): void
     {
         $stored = array(

--- a/tests/stubs/wordpress.php
+++ b/tests/stubs/wordpress.php
@@ -628,7 +628,7 @@ if (! function_exists('is_admin')) {
 if (! function_exists('determine_locale')) {
     function determine_locale()
     {
-        return 'en_US';
+        return $GLOBALS['wp_test_locale'] ?? 'en_US';
     }
 }
 


### PR DESCRIPTION
## Summary
- normalize language codes throughout CurrentLanguage::resolve, including locale fallbacks and path/query detection
- clear cached language when settings change and normalize allowed languages when remembering the frontend preference
- document regional code support and extend unit coverage for locale normalization and dynamic/post translation flows

## Testing
- composer qa

------
https://chatgpt.com/codex/tasks/task_e_68d44855917c832f9ee6873dbf56ca01