### PR TITLE
Add glossary configuration for translation providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ FP Multilanguage è un plugin WordPress enterprise-ready per orchestrare contenu
 - **Gestione impostazioni** con pagina admin, salvataggio async via REST, schede (Generale/Provider/SEO/Quote) e script `admin.js`.
 - **Servizio di traduzione** con caching multi-layer, rate limiting, quote aggregate (`fp_multilanguage_quota`), retry con backoff e fallback manuali.
 - **Provider dedicati** (`GoogleProvider`, `DeepLProvider`) basati su `TranslationProviderInterface` e estensibilità tramite filtro `fp_multilanguage_provider_sequence`.
+- **Glossari personalizzati** configurabili da backend per Google Cloud e DeepL (ID risorsa, ignore-case, livello di formalità).
 - **Risoluzione lingua corrente** tramite query var, cookie, preferenze utente, URL rewriting e filtri.
 - **Gestione contenuti** con traduzione automatica su `save_post`, esposizione REST/CLI, filtri front-end (`the_content`, `the_title`, `get_the_excerpt`, `wp_get_attachment_image_attributes`) e metadati persistiti.
 - **Stringhe dinamiche** con storage in tabella custom (`wp_fp_multilanguage_strings`), API REST, AJAX editor inline e fallback JS.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,10 +2,13 @@
 
 ## In lavorazione
 
-- Supporto glossari personalizzati per provider (Google/DeepL) con UI dedicata.
 - Traduzione media (alt text, caption, file names) e sincronizzazione su CDN.
 - Localizzazione commenti front-end con moderazione multilingua.
 - Integrazione con cache page builders (Elementor, Gutenberg patterns complessi).
+
+## Completate
+
+- Supporto glossari personalizzati per provider (Google/DeepL) con UI dedicata.
 
 ## Idee future
 

--- a/fp-multilanguage/includes/Admin/Settings.php
+++ b/fp-multilanguage/includes/Admin/Settings.php
@@ -28,18 +28,22 @@ class Settings {
 		'source_language'   => 'en',
 		'fallback_language' => 'en',
 		'target_languages'  => array( 'it' ),
-		'providers'         => array(
-			'google' => array(
-				'enabled' => false,
-				'api_key' => '',
-				'timeout' => 20,
-			),
-			'deepl'  => array(
-				'enabled'  => false,
-				'api_key'  => '',
-				'endpoint' => 'https://api.deepl.com/v2/translate',
-			),
-		),
+                'providers'         => array(
+                        'google' => array(
+                                'enabled'              => false,
+                                'api_key'              => '',
+                                'timeout'              => 20,
+                                'glossary_id'          => '',
+                                'glossary_ignore_case' => false,
+                        ),
+                        'deepl'  => array(
+                                'enabled'     => false,
+                                'api_key'     => '',
+                                'endpoint'    => 'https://api.deepl.com/v2/translate',
+                                'glossary_id' => '',
+                                'formality'   => 'default',
+                        ),
+                ),
 		'auto_translate'    => true,
 		'seo'               => array(
 			'hreflang'   => true,
@@ -323,30 +327,71 @@ class Settings {
 		<?php
 	}
 
-	public function render_google_field(): void {
-		$options  = $this->get_options();
-		$provider = $options['providers']['google'] ?? array();
-		?>
-		<label>
+        public function render_google_field(): void {
+                $options  = $this->get_options();
+                $provider = $options['providers']['google'] ?? array();
+                ?>
+                <label>
 			<input type="checkbox" name="<?php echo esc_attr( self::OPTION_NAME ); ?>[providers][google][enabled]" value="1" <?php checked( ! empty( $provider['enabled'] ) ); ?>>
 			<?php esc_html_e( 'Abilita Google Cloud Translation', 'fp-multilanguage' ); ?>
 		</label>
-		<input type="text" class="regular-text" name="<?php echo esc_attr( self::OPTION_NAME ); ?>[providers][google][api_key]" value="<?php echo esc_attr( $provider['api_key'] ?? '' ); ?>">
-		<?php
-	}
+                <input type="text" class="regular-text" name="<?php echo esc_attr( self::OPTION_NAME ); ?>[providers][google][api_key]" value="<?php echo esc_attr( $provider['api_key'] ?? '' ); ?>">
+                <p class="description"><?php esc_html_e( 'Chiave API del progetto Google Cloud con Translation API abilitata.', 'fp-multilanguage' ); ?></p>
+                <p>
+                        <label for="fp-multilanguage-google-glossary">
+                                <?php esc_html_e( 'ID glossario personalizzato', 'fp-multilanguage' ); ?>
+                        </label>
+                        <input id="fp-multilanguage-google-glossary" type="text" class="regular-text" name="<?php echo esc_attr( self::OPTION_NAME ); ?>[providers][google][glossary_id]" value="<?php echo esc_attr( $provider['glossary_id'] ?? '' ); ?>" placeholder="projects/xxx/locations/xx/glossaries/xxx">
+                        <span class="description"><?php esc_html_e( 'Percorso completo della risorsa glossario. Lascia vuoto per disabilitare.', 'fp-multilanguage' ); ?></span>
+                </p>
+                <p>
+                        <label>
+                                <input type="checkbox" name="<?php echo esc_attr( self::OPTION_NAME ); ?>[providers][google][glossary_ignore_case]" value="1" <?php checked( ! empty( $provider['glossary_ignore_case'] ) ); ?>>
+                                <?php esc_html_e( 'Applica il glossario ignorando maiuscole/minuscole.', 'fp-multilanguage' ); ?>
+                        </label>
+                </p>
+                <?php
+        }
 
-	public function render_deepl_field(): void {
-		$options  = $this->get_options();
-		$provider = $options['providers']['deepl'] ?? array();
-		?>
-		<label>
-			<input type="checkbox" name="<?php echo esc_attr( self::OPTION_NAME ); ?>[providers][deepl][enabled]" value="1" <?php checked( ! empty( $provider['enabled'] ) ); ?>>
-			<?php esc_html_e( 'Abilita DeepL', 'fp-multilanguage' ); ?>
-		</label>
-		<input type="text" class="regular-text" name="<?php echo esc_attr( self::OPTION_NAME ); ?>[providers][deepl][api_key]" value="<?php echo esc_attr( $provider['api_key'] ?? '' ); ?>">
-		<p class="description"><?php esc_html_e( 'Utilizza endpoint EU/US personalizzato se necessario.', 'fp-multilanguage' ); ?></p>
-		<?php
-	}
+        public function render_deepl_field(): void {
+                $options  = $this->get_options();
+                $provider = $options['providers']['deepl'] ?? array();
+                ?>
+                <label>
+                        <input type="checkbox" name="<?php echo esc_attr( self::OPTION_NAME ); ?>[providers][deepl][enabled]" value="1" <?php checked( ! empty( $provider['enabled'] ) ); ?>>
+                        <?php esc_html_e( 'Abilita DeepL', 'fp-multilanguage' ); ?>
+                </label>
+                <input type="text" class="regular-text" name="<?php echo esc_attr( self::OPTION_NAME ); ?>[providers][deepl][api_key]" value="<?php echo esc_attr( $provider['api_key'] ?? '' ); ?>">
+                <p class="description"><?php esc_html_e( 'Utilizza endpoint EU/US personalizzato se necessario.', 'fp-multilanguage' ); ?></p>
+                <p>
+                        <label for="fp-multilanguage-deepl-glossary">
+                                <?php esc_html_e( 'ID glossario DeepL', 'fp-multilanguage' ); ?>
+                        </label>
+                        <input id="fp-multilanguage-deepl-glossary" type="text" class="regular-text" name="<?php echo esc_attr( self::OPTION_NAME ); ?>[providers][deepl][glossary_id]" value="<?php echo esc_attr( $provider['glossary_id'] ?? '' ); ?>" placeholder="1234-5678-...">
+                        <span class="description"><?php esc_html_e( 'Inserisci l\'ID del glossario pubblicato su DeepL (opzionale).', 'fp-multilanguage' ); ?></span>
+                </p>
+                <p>
+                        <label for="fp-multilanguage-deepl-formality">
+                                <?php esc_html_e( 'Livello di formalità', 'fp-multilanguage' ); ?>
+                        </label>
+                        <select id="fp-multilanguage-deepl-formality" name="<?php echo esc_attr( self::OPTION_NAME ); ?>[providers][deepl][formality]">
+                                <?php
+                                $formalities = array(
+                                        'default' => __( 'Predefinito', 'fp-multilanguage' ),
+                                        'more'    => __( 'Più formale', 'fp-multilanguage' ),
+                                        'less'    => __( 'Meno formale', 'fp-multilanguage' ),
+                                );
+                                $selected   = isset( $provider['formality'] ) ? (string) $provider['formality'] : 'default';
+                                foreach ( $formalities as $value => $label ) :
+                                        ?>
+                                        <option value="<?php echo esc_attr( $value ); ?>" <?php selected( $selected, $value ); ?>><?php echo esc_html( $label ); ?></option>
+                                        <?php
+                                endforeach;
+                                ?>
+                        </select>
+                </p>
+                <?php
+        }
 
 	public function render_seo_field(): void {
 		$options = $this->get_options();
@@ -451,28 +496,56 @@ class Settings {
 
 			$sanitized['auto_translate'] = ! empty( $sanitized['auto_translate'] );
 
-		foreach ( array( 'google', 'deepl' ) as $provider ) {
-				$providerOptions            = $sanitized['providers'][ $provider ] ?? array();
-				$providerOptions            = wp_parse_args( $providerOptions, self::$defaults['providers'][ $provider ] );
-				$providerOptions['enabled'] = ! empty( $providerOptions['enabled'] );
-				$providerOptions['api_key'] = sanitize_text_field( $providerOptions['api_key'] );
-			if ( $providerOptions['enabled'] && '' === $providerOptions['api_key'] ) {
-					$providerOptions['enabled'] = false;
+                foreach ( array( 'google', 'deepl' ) as $provider ) {
+                                $providerOptions            = $sanitized['providers'][ $provider ] ?? array();
+                                $providerOptions            = wp_parse_args( $providerOptions, self::$defaults['providers'][ $provider ] );
+                                $providerOptions['enabled'] = ! empty( $providerOptions['enabled'] );
+                                $providerOptions['api_key'] = sanitize_text_field( $providerOptions['api_key'] );
+                        if ( isset( $providerOptions['timeout'] ) ) {
+                                $providerOptions['timeout'] = max( 5, (int) $providerOptions['timeout'] );
+                        }
+                        if ( $providerOptions['enabled'] && '' === $providerOptions['api_key'] ) {
+                                        $providerOptions['enabled'] = false;
 
-					$providerLabel = 'deepl' === $provider ? 'DeepL' : ucfirst( $provider );
-					$message       = sprintf(
+                                        $providerLabel = 'deepl' === $provider ? 'DeepL' : ucfirst( $provider );
+                                        $message       = sprintf(
 							/* translators: %s is the provider name. */
 						__( 'Il provider %s è stato disabilitato perché manca la chiave API.', 'fp-multilanguage' ),
 						$providerLabel
 					);
 
 					$this->notices->add_notice( $message, 'warning', false );
-			}
-			if ( isset( $providerOptions['endpoint'] ) ) {
-					$providerOptions['endpoint'] = esc_url_raw( $providerOptions['endpoint'] );
-			}
-				$sanitized['providers'][ $provider ] = $providerOptions;
-		}
+                        }
+                        if ( isset( $providerOptions['endpoint'] ) ) {
+                                        $providerOptions['endpoint'] = esc_url_raw( $providerOptions['endpoint'] );
+                        }
+                        if ( isset( $providerOptions['glossary_id'] ) ) {
+                                $glossaryId = sanitize_text_field( $providerOptions['glossary_id'] );
+                                $glossaryId = html_entity_decode( $glossaryId, ENT_QUOTES, 'UTF-8' );
+                                $glossaryId = preg_replace( '/[\r\n]+/', '', $glossaryId );
+                                if ( null === $glossaryId ) {
+                                        $glossaryId = '';
+                                }
+
+                                $providerOptions['glossary_id'] = trim( $glossaryId );
+                        }
+                        if ( 'google' === $provider ) {
+                                $providerOptions['glossary_ignore_case'] = ! empty( $providerOptions['glossary_ignore_case'] );
+                                if ( '' === $providerOptions['glossary_id'] ) {
+                                        $providerOptions['glossary_ignore_case'] = false;
+                                }
+                        }
+                        if ( 'deepl' === $provider ) {
+                                $formality = strtolower( sanitize_text_field( (string) ( $providerOptions['formality'] ?? '' ) ) );
+                                $allowed   = array( 'default', 'more', 'less' );
+                                if ( ! in_array( $formality, $allowed, true ) ) {
+                                        $formality = 'default';
+                                }
+
+                                $providerOptions['formality'] = $formality;
+                        }
+                                $sanitized['providers'][ $provider ] = $providerOptions;
+                }
 
 		if ( ! isset( $sanitized['seo'] ) || ! is_array( $sanitized['seo'] ) ) {
 			$sanitized['seo'] = self::$defaults['seo'];

--- a/fp-multilanguage/includes/Services/Providers/DeepLProvider.php
+++ b/fp-multilanguage/includes/Services/Providers/DeepLProvider.php
@@ -30,25 +30,30 @@ class DeepLProvider implements TranslationProviderInterface {
 			'target_lang' => strtoupper( $target ),
 		);
 
-		if ( ! empty( $options['formality'] ) ) {
-			$body['formality'] = $options['formality'];
-		}
+                $glossaryId = isset( $options['glossary_id'] ) ? (string) $options['glossary_id'] : '';
+                if ( '' === $glossaryId && ! empty( $options['glossary'] ) ) {
+                        $glossaryId = (string) $options['glossary'];
+                }
 
-		if ( ! empty( $options['glossary'] ) ) {
-			$body['glossary_id'] = $options['glossary'];
-		}
+                if ( $glossaryId !== '' ) {
+                        $body['glossary_id'] = $glossaryId;
+                }
 
-		$format = strtolower( (string) ( $options['format'] ?? 'text' ) );
-		if ( $format === 'html' ) {
-			$body['tag_handling'] = 'html';
-			if ( ! empty( $options['preserve_tags'] ) ) {
+                $format = strtolower( (string) ( $options['format'] ?? 'text' ) );
+                if ( $format === 'html' ) {
+                        $body['tag_handling'] = 'html';
+                        if ( ! empty( $options['preserve_tags'] ) ) {
 				$body['non_splitting_tags'] = implode( ',', (array) $options['preserve_tags'] );
 			}
 		}
 
 		$timeout = isset( $options['timeout'] ) ? (int) $options['timeout'] : 20;
 
-		$response = wp_remote_post(
+                if ( isset( $options['formality'] ) && is_string( $options['formality'] ) && $options['formality'] !== '' && 'default' !== $options['formality'] ) {
+                        $body['formality'] = $options['formality'];
+                }
+
+                $response = wp_remote_post(
 			$endpoint,
 			array(
 				'timeout' => max( 5, $timeout ),

--- a/fp-multilanguage/includes/Services/Providers/GoogleProvider.php
+++ b/fp-multilanguage/includes/Services/Providers/GoogleProvider.php
@@ -33,9 +33,22 @@ class GoogleProvider implements TranslationProviderInterface {
 			'format' => $format,
 		);
 
-		if ( ! empty( $options['glossary'] ) ) {
-			$body['glossaryConfig'] = $options['glossary'];
-		}
+                $glossaryConfig = array();
+                if ( ! empty( $options['glossary'] ) && is_array( $options['glossary'] ) ) {
+                        $glossaryConfig = $options['glossary'];
+                }
+
+                $glossaryId = isset( $options['glossary_id'] ) ? (string) $options['glossary_id'] : '';
+                if ( $glossaryId !== '' ) {
+                        $glossaryConfig = array( 'glossary' => $glossaryId );
+                        if ( ! empty( $options['glossary_ignore_case'] ) ) {
+                                $glossaryConfig['ignoreCase'] = true;
+                        }
+                }
+
+                if ( ! empty( $glossaryConfig ) ) {
+                        $body['glossaryConfig'] = $glossaryConfig;
+                }
 
 		$response = wp_remote_post(
 			$url,

--- a/tests/SettingsTest.php
+++ b/tests/SettingsTest.php
@@ -77,6 +77,39 @@ class SettingsTest extends TestCase
         $this->assertFalse( $sanitized['providers']['deepl']['enabled'], 'Il provider DeepL deve essere disabilitato senza chiave API.' );
     }
 
+    public function test_sanitize_normalizes_provider_glossary_options(): void
+    {
+        $input = array(
+            'providers' => array(
+                'google' => array(
+                    'enabled'              => true,
+                    'api_key'              => 'key',
+                    'glossary_id'          => '  projects/example/locations/eu/glossaries/demo  ',
+                    'glossary_ignore_case' => '1',
+                    'timeout'              => '2',
+                ),
+                'deepl' => array(
+                    'enabled'     => true,
+                    'api_key'     => 'secret',
+                    'endpoint'    => 'https://api.deepl.com/v2/translate',
+                    'glossary_id' => " 1234-5678 \n",
+                    'formality'   => 'MORE',
+                ),
+            ),
+        );
+
+        $sanitized = $this->settings->sanitize( $input );
+
+        $google = $sanitized['providers']['google'];
+        $this->assertSame( 'projects/example/locations/eu/glossaries/demo', $google['glossary_id'] );
+        $this->assertTrue( $google['glossary_ignore_case'], 'L\'opzione ignoreCase deve essere attivata.' );
+        $this->assertSame( 5, $google['timeout'], 'Il timeout deve rispettare il valore minimo di 5 secondi.' );
+
+        $deepl = $sanitized['providers']['deepl'];
+        $this->assertSame( '1234-5678', $deepl['glossary_id'] );
+        $this->assertSame( 'more', $deepl['formality'] );
+    }
+
     public function test_sanitize_normalizes_language_formats(): void
     {
         $input = array(

--- a/tests/TranslationServiceTest.php
+++ b/tests/TranslationServiceTest.php
@@ -22,7 +22,7 @@ class TranslationServiceTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        global $wp_test_options, $wp_test_cache, $wp_test_transients, $wp_remote_post_calls, $wp_test_filters, $wp_remote_post_failures, $wp_remote_post_invalid_json, $wp_test_actions, $wp_test_textdomains;
+        global $wp_test_options, $wp_test_cache, $wp_test_transients, $wp_remote_post_calls, $wp_test_filters, $wp_remote_post_failures, $wp_remote_post_invalid_json, $wp_test_actions, $wp_test_textdomains, $wp_remote_post_requests;
         $wp_test_options = [];
         $wp_test_cache = [];
         $wp_test_transients = [];
@@ -32,6 +32,7 @@ class TranslationServiceTest extends TestCase
         $wp_remote_post_invalid_json = [];
         $wp_test_actions = [];
         $wp_test_textdomains = [];
+        $wp_remote_post_requests = [];
 
         update_option(Settings::OPTION_NAME, [
             'source_language' => 'en',
@@ -167,6 +168,44 @@ class TranslationServiceTest extends TestCase
         $this->assertSame(2, $wp_remote_post_calls['translation.googleapis.com'] ?? 0, 'Il provider deve essere chiamato due volte dopo un errore temporaneo.');
     }
 
+    public function test_google_payload_includes_glossary_config(): void
+    {
+        update_option(Settings::OPTION_NAME, [
+            'source_language' => 'en',
+            'fallback_language' => 'en',
+            'target_languages' => ['it'],
+            'auto_translate' => true,
+            'providers' => [
+                'google' => [
+                    'enabled' => true,
+                    'api_key' => 'with-glossary',
+                    'glossary_id' => 'projects/demo/locations/global/glossaries/catalog',
+                    'glossary_ignore_case' => true,
+                ],
+                'deepl' => [
+                    'enabled' => false,
+                    'api_key' => '',
+                    'endpoint' => 'https://api.deepl.com/v2/translate',
+                ],
+            ],
+            'seo' => [],
+            'quote_tracking' => [],
+        ]);
+
+        TranslationService::flush_cache();
+        $result = $this->service->translate_text('Glossary content', 'en', 'it');
+
+        $this->assertSame('google:Glossary content', $result);
+
+        global $wp_remote_post_requests;
+        $request = $wp_remote_post_requests['translation.googleapis.com'][0] ?? [];
+        $decoded = $request['decoded_body'] ?? [];
+
+        $this->assertArrayHasKey('glossaryConfig', $decoded, 'La richiesta deve includere la configurazione del glossario.');
+        $this->assertSame('projects/demo/locations/global/glossaries/catalog', $decoded['glossaryConfig']['glossary'] ?? '');
+        $this->assertTrue($decoded['glossaryConfig']['ignoreCase'] ?? false);
+    }
+
     public function test_uses_strlen_when_mb_string_extension_missing(): void
     {
         $service = new class ($this->logger, $this->notices, $this->settings) extends TranslationService {
@@ -192,6 +231,43 @@ class TranslationServiceTest extends TestCase
         $this->assertIsArray($quota, 'La quota deve essere salvata come array.');
         $this->assertSame(1, $quota['google']['it']['requests'] ?? 0, 'Il numero di richieste deve aumentare.');
         $this->assertSame(strlen($text), $quota['google']['it']['characters'] ?? 0, 'La lunghezza deve usare strlen come fallback.');
+    }
+
+    public function test_deepl_payload_includes_glossary_and_formality(): void
+    {
+        update_option(Settings::OPTION_NAME, [
+            'source_language' => 'en',
+            'fallback_language' => 'en',
+            'target_languages' => ['it'],
+            'auto_translate' => true,
+            'providers' => [
+                'google' => [
+                    'enabled' => false,
+                    'api_key' => '',
+                ],
+                'deepl' => [
+                    'enabled' => true,
+                    'api_key' => 'deepl-glossary',
+                    'endpoint' => 'https://api.deepl.com/v2/translate',
+                    'glossary_id' => '1234-5678',
+                    'formality' => 'more',
+                ],
+            ],
+            'seo' => [],
+            'quote_tracking' => [],
+        ]);
+
+        TranslationService::flush_cache();
+        $result = $this->service->translate_text('DeepL request', 'en', 'it');
+
+        $this->assertSame('deepl:DeepL request', $result);
+
+        global $wp_remote_post_requests;
+        $request = $wp_remote_post_requests['api.deepl.com'][0] ?? [];
+        $decoded = $request['decoded_body'] ?? [];
+
+        $this->assertSame('1234-5678', $decoded['glossary_id'] ?? '', 'La richiesta deve includere l\'ID del glossario.');
+        $this->assertSame('more', $decoded['formality'] ?? '');
     }
 
     public function test_preserves_html_tags_when_format_is_html(): void

--- a/tests/stubs/wordpress.php
+++ b/tests/stubs/wordpress.php
@@ -31,6 +31,11 @@ if (! isset($wp_remote_post_invalid_json)) {
     $wp_remote_post_invalid_json = [];
 }
 
+global $wp_remote_post_requests;
+if (! isset($wp_remote_post_requests)) {
+    $wp_remote_post_requests = [];
+}
+
 global $wp_test_filters;
 if (! isset($wp_test_filters)) {
     $wp_test_filters = [];
@@ -205,12 +210,26 @@ if (! function_exists('wp_json_encode')) {
 if (! function_exists('wp_remote_post')) {
     function wp_remote_post($url, $args = [])
     {
-        global $wp_remote_post_calls, $wp_remote_post_failures, $wp_remote_post_invalid_json;
+        global $wp_remote_post_calls, $wp_remote_post_failures, $wp_remote_post_invalid_json, $wp_remote_post_requests;
         $host = parse_url($url, PHP_URL_HOST) ?: $url;
         if (! isset($wp_remote_post_calls[$host])) {
             $wp_remote_post_calls[$host] = 0;
         }
         $wp_remote_post_calls[$host]++;
+
+        if (isset($wp_remote_post_requests[$host])) {
+            $wp_remote_post_requests[$host][] = [
+                'url' => $url,
+                'args' => $args,
+            ];
+        } else {
+            $wp_remote_post_requests[$host] = [
+                [
+                    'url' => $url,
+                    'args' => $args,
+                ],
+            ];
+        }
 
         if (isset($wp_remote_post_failures[$host]) && $wp_remote_post_failures[$host] > 0) {
             $wp_remote_post_failures[$host]--;
@@ -242,6 +261,8 @@ if (! function_exists('wp_remote_post')) {
         } else {
             $decoded = $body;
         }
+
+        $wp_remote_post_requests[$host][count($wp_remote_post_requests[$host]) - 1]['decoded_body'] = $decoded;
 
         $text = '';
         if (is_array($decoded)) {
@@ -451,6 +472,15 @@ if (! function_exists('checked')) {
     {
         if ((bool) $checked === (bool) $current) {
             echo 'checked="checked"';
+        }
+    }
+}
+
+if (! function_exists('selected')) {
+    function selected($selected, $current = true)
+    {
+        if ((string) $selected === (string) $current) {
+            echo 'selected="selected"';
         }
     }
 }


### PR DESCRIPTION
## Summary
- add glossary and formality configuration to provider defaults, sanitization, and admin UI
- update Google/DeepL providers to send the configured glossary metadata when translating
- extend the test suite and stubs to cover glossary payloads and sanitization, and document roadmap progress

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d457776860832f9e0c757b4c40ca75