### PR TITLE
Handle service bootstrapping during uninstall

### DIFF
--- a/fp-multilanguage/includes/Plugin.php
+++ b/fp-multilanguage/includes/Plugin.php
@@ -176,16 +176,25 @@ class Plugin {
 	}
 
 	public static function uninstall(): void {
+		$instance  = self::instance();
+		$container = $instance->get_container();
+
+		if ( ! $container->has( 'migrator' ) ) {
+			$instance->register_services();
+			$container = $instance->get_container();
+		}
+
 		delete_option( Settings::OPTION_NAME );
 		delete_option( Settings::MANUAL_STRINGS_OPTION );
 		delete_option( 'fp_multilanguage_quota' );
 		delete_option( self::VERSION_OPTION );
 		delete_option( SEO::SLUG_INDEX_OPTION );
 
-		/** @var Migrator $migrator */
-		$migrator = self::instance()->container->get( 'migrator' );
-                $migrator->drop_tables();
-        }
+		$migrator = $container->get( 'migrator' );
+		if ( $migrator instanceof Migrator ) {
+			$migrator->drop_tables();
+		}
+	}
 
         private function register_services(): void {
                 $container = $this->container;

--- a/tests/PluginTest.php
+++ b/tests/PluginTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace FPMultilanguage\Tests;
 
+use FPMultilanguage\Admin\Settings;
+use FPMultilanguage\Install\Migrator;
 use FPMultilanguage\Plugin;
 use PHPUnit\Framework\TestCase;
 
@@ -94,5 +96,46 @@ class PluginTest extends TestCase
             get_option('fp_multilanguage_cache_version'),
             'Non devono esserci modifiche alla cache quando la versione coincide.'
         );
+    }
+
+    public function test_uninstall_cleans_options_and_drops_tables(): void
+    {
+        if (! defined('FP_MULTILANGUAGE_PATH')) {
+            define('FP_MULTILANGUAGE_PATH', dirname(__DIR__) . '/fp-multilanguage/');
+        }
+
+        if (! defined('FP_MULTILANGUAGE_VERSION')) {
+            define('FP_MULTILANGUAGE_VERSION', '1.0.0');
+        }
+
+        Plugin::instance()->init();
+
+        $plugin     = Plugin::instance();
+        $container  = $plugin->get_container();
+        $dropper    = new class() extends Migrator {
+            public int $dropCalls = 0;
+
+            public function drop_tables(): void
+            {
+                $this->dropCalls++;
+            }
+        };
+
+        $container->set('migrator', $dropper);
+
+        update_option(Settings::OPTION_NAME, ['foo' => 'bar']);
+        update_option(Settings::MANUAL_STRINGS_OPTION, ['manual' => []]);
+        update_option('fp_multilanguage_quota', ['google' => []]);
+        update_option('fp_multilanguage_version', '0.9.0');
+        update_option('fp_multilanguage_slug_index', ['slug' => ['post_id' => 123]]);
+
+        Plugin::uninstall();
+
+        $this->assertSame('missing', get_option(Settings::OPTION_NAME, 'missing'));
+        $this->assertSame('missing', get_option(Settings::MANUAL_STRINGS_OPTION, 'missing'));
+        $this->assertSame('missing', get_option('fp_multilanguage_quota', 'missing'));
+        $this->assertSame('missing', get_option('fp_multilanguage_version', 'missing'));
+        $this->assertSame('missing', get_option('fp_multilanguage_slug_index', 'missing'));
+        $this->assertSame(1, $dropper->dropCalls, 'La tabella personalizzata deve essere eliminata.');
     }
 }

--- a/tests/stubs/wordpress.php
+++ b/tests/stubs/wordpress.php
@@ -121,6 +121,17 @@ if (! function_exists('update_option')) {
     }
 }
 
+if (! function_exists('delete_option')) {
+    function delete_option($name)
+    {
+        global $wp_test_options;
+
+        unset($wp_test_options[$name]);
+
+        return true;
+    }
+}
+
 if (! function_exists('wp_parse_args')) {
     function wp_parse_args($args, $defaults = [])
     {


### PR DESCRIPTION
## Summary
- ensure the uninstall routine boots the service container before attempting to drop custom tables
- guard against missing migrator instances while still purging all plugin options
- cover the uninstall flow with a dedicated unit test and extend the WordPress stubs with delete_option

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d4fc9ce55c832fbdea723d462a4564