### PR TITLE
Add REST nonce validation for settings updates

### DIFF
--- a/fp-multilanguage/includes/Admin/Settings.php
+++ b/fp-multilanguage/includes/Admin/Settings.php
@@ -204,13 +204,22 @@ class Settings {
 	}
 
 	public function rest_update_settings( WP_REST_Request $request ) {
-			$params = $request->get_json_params();
-		if ( ! is_array( $params ) ) {
-				$message = __( 'Payload non valido', 'fp-multilanguage' );
-				$this->logger->error( $message );
-				$this->notices->add_error( $message );
+		if ( ! $this->verify_rest_nonce( $request ) ) {
+			$message = __( 'Nonce di sicurezza non valido.', 'fp-multilanguage' );
 
-				return new WP_Error( 'invalid_payload', $message, array( 'status' => 400 ) );
+			$this->logger->warning( $message );
+			$this->notices->add_error( $message );
+
+			return new WP_Error( 'invalid_nonce', $message, array( 'status' => 403 ) );
+		}
+
+		$params = $request->get_json_params();
+		if ( ! is_array( $params ) ) {
+			$message = __( 'Payload non valido', 'fp-multilanguage' );
+			$this->logger->error( $message );
+			$this->notices->add_error( $message );
+
+			return new WP_Error( 'invalid_payload', $message, array( 'status' => 400 ) );
 		}
 
 		$options = $this->sanitize( $params );
@@ -224,6 +233,46 @@ class Settings {
 		return rest_ensure_response( $options );
 	}
 
+
+	private function verify_rest_nonce( WP_REST_Request $request ): bool {
+		$nonce = '';
+
+		if ( method_exists( $request, 'get_header' ) ) {
+			$headerNonce = $request->get_header( 'X-WP-Nonce' );
+			if ( is_string( $headerNonce ) ) {
+				$nonce = $headerNonce;
+			}
+		}
+
+		if ( '' === $nonce && method_exists( $request, 'get_param' ) ) {
+			$paramNonce = $request->get_param( '_wpnonce' );
+			if ( is_string( $paramNonce ) ) {
+				$nonce = $paramNonce;
+			}
+		}
+
+		if ( '' === $nonce ) {
+			return false;
+		}
+
+		if ( function_exists( 'wp_unslash' ) ) {
+			$nonce = wp_unslash( $nonce );
+		}
+
+		if ( function_exists( 'sanitize_text_field' ) ) {
+			$nonce = sanitize_text_field( $nonce );
+		}
+
+		if ( '' === $nonce ) {
+			return false;
+		}
+
+		if ( function_exists( 'wp_verify_nonce' ) ) {
+			return false !== wp_verify_nonce( $nonce, self::NONCE_ACTION );
+		}
+
+		return true;
+	}
 	public function enqueue_assets( string $hook ): void {
 		if ( $hook !== 'settings_page_fp-multilanguage-settings' ) {
 			return;

--- a/tests/SettingsTest.php
+++ b/tests/SettingsTest.php
@@ -186,4 +186,41 @@ class SettingsTest extends TestCase
         $fallback = get_option( 'fp_multilanguage_strings', array() );
         $this->assertArrayNotHasKey( $key, $fallback );
     }
+
+    public function test_rest_update_settings_requires_valid_nonce(): void
+    {
+        global $wp_test_nonce_expectations;
+
+        $wp_test_nonce_expectations = array(
+            'fp_multilanguage_settings' => array( 'valid-rest-nonce' ),
+        );
+
+        $request = new \WP_REST_Request();
+        $request->set_json_params(
+            array(
+                'source_language'   => 'en',
+                'fallback_language' => 'en',
+                'target_languages'  => array( 'it' ),
+                'providers'         => array(),
+                'seo'               => array(),
+                'quote_tracking'    => array(),
+            )
+        );
+
+        $response = $this->settings->rest_update_settings( $request );
+        $this->assertInstanceOf( \WP_Error::class, $response );
+        $this->assertSame( 'invalid_nonce', $response->get_error_code() );
+
+        $request->set_header( 'X-WP-Nonce', 'invalid' );
+        $response = $this->settings->rest_update_settings( $request );
+        $this->assertInstanceOf( \WP_Error::class, $response );
+        $this->assertSame( 'invalid_nonce', $response->get_error_code() );
+
+        $request->set_header( 'X-WP-Nonce', 'valid-rest-nonce' );
+        $response = $this->settings->rest_update_settings( $request );
+        $this->assertIsArray( $response );
+        $this->assertSame( 'en', $response['source_language'] );
+
+        $wp_test_nonce_expectations = array();
+    }
 }

--- a/tests/stubs/wordpress.php
+++ b/tests/stubs/wordpress.php
@@ -56,6 +56,11 @@ if (! isset($wp_test_actions)) {
     $wp_test_actions = [];
 }
 
+global $wp_test_nonce_expectations;
+if (! isset($wp_test_nonce_expectations)) {
+    $wp_test_nonce_expectations = [];
+}
+
 global $wp_test_textdomains;
 if (! isset($wp_test_textdomains)) {
     $wp_test_textdomains = [];
@@ -802,7 +807,85 @@ if (! function_exists('delete_comment_meta')) {
 if (! function_exists('wp_verify_nonce')) {
     function wp_verify_nonce($nonce, $action)
     {
+        global $wp_test_nonce_expectations;
+
+        if (isset($wp_test_nonce_expectations[$action])) {
+            return in_array($nonce, (array) $wp_test_nonce_expectations[$action], true);
+        }
+
         return true;
+    }
+}
+
+if (! class_exists('WP_REST_Request')) {
+    class WP_REST_Request
+    {
+        /** @var array<string, mixed> */
+        private array $params = [];
+
+        /** @var array<string, mixed> */
+        private array $json_params = [];
+
+        /** @var array<string, mixed> */
+        private array $headers = [];
+
+        /**
+         * @param array<string, mixed> $params
+         */
+        public function __construct(array $params = [])
+        {
+            $this->params = $params;
+        }
+
+        /**
+         * @return array<string, mixed>
+         */
+        public function get_json_params()
+        {
+            return $this->json_params;
+        }
+
+        /**
+         * @param array<string, mixed> $params
+         */
+        public function set_json_params(array $params): void
+        {
+            $this->json_params = $params;
+        }
+
+        /**
+         * @return mixed
+         */
+        public function get_param(string $key)
+        {
+            return $this->params[$key] ?? null;
+        }
+
+        /**
+         * @param mixed $value
+         */
+        public function set_param(string $key, $value): void
+        {
+            $this->params[$key] = $value;
+        }
+
+        /**
+         * @return mixed
+         */
+        public function get_header(string $key)
+        {
+            $key = strtolower($key);
+
+            return $this->headers[$key] ?? '';
+        }
+
+        /**
+         * @param mixed $value
+         */
+        public function set_header(string $key, $value): void
+        {
+            $this->headers[strtolower($key)] = $value;
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- enforce nonce validation before accepting REST settings updates
- add lightweight WP_REST_Request test stub and configurable nonce expectations for unit tests
- cover the new security flow with a PHPUnit test to ensure invalid nonces are rejected

## Testing
- vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68d51c1e0124832fabe78637eaf94113