### PR TITLE
Harden language switcher query handling

### DIFF
--- a/fp-multilanguage/includes/Admin/Settings.php
+++ b/fp-multilanguage/includes/Admin/Settings.php
@@ -811,8 +811,14 @@ class Settings {
 		$context  = '';
 		$original = '';
 
-                $existing = $wpdb->get_row( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-			$wpdb->prepare( "SELECT context, original FROM {$table} WHERE string_key = %s", $key ),
+		$table_name = esc_sql( $table );
+// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQL.NotPrepared -- table name sanitized above.
+		$existing = $wpdb->get_row( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$wpdb->prepare(
+				"SELECT context, original FROM {$table_name} WHERE string_key = %s",
+				$key
+			),
+// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQL.NotPrepared
 			'ARRAY_A'
 		);
 
@@ -855,16 +861,16 @@ class Settings {
 			array( '%s', '%s', '%s', '%s', '%s' )
 		);
 	}
-        private static function manual_strings_table_exists( string $table ): bool {
-			global $wpdb;
+	private static function manual_strings_table_exists( string $table ): bool {
+		global $wpdb;
 
 		if ( ! isset( $wpdb ) || ! $wpdb instanceof \wpdb ) {
 				return false;
 		}
 
-			$exists = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$exists = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 
-			return null !== $exists;
+		return null !== $exists;
 	}
 
 	private static function sync_manual_string_fallback( string $key, array $translations ): void {

--- a/fp-multilanguage/includes/Widgets/LanguageSwitcher.php
+++ b/fp-multilanguage/includes/Widgets/LanguageSwitcher.php
@@ -160,16 +160,65 @@ class LanguageSwitcher extends WP_Widget {
 
 		foreach ( wp_unslash( (array) $_GET ) as $key => $value ) {
 			if ( strtolower( (string) $key ) === 'fp_lang' ) {
-					continue;
+						continue;
 			}
 
-				$queryArgs[ $key ] = $value;
+				$sanitizedKey = sanitize_key( (string) $key );
+			if ( '' === $sanitizedKey ) {
+							continue;
+			}
+
+							$sanitizedValue = $this->sanitize_query_arg_value( $value );
+			if ( null === $sanitizedValue ) {
+				continue;
+			}
+
+							$queryArgs[ $sanitizedKey ] = $sanitizedValue;
 		}
 
 		if ( empty( $queryArgs ) ) {
 			return $baseUrl;
 		}
 
-			return add_query_arg( $queryArgs, $baseUrl );
+						return add_query_arg( $queryArgs, $baseUrl );
+	}
+
+		/**
+		 * @param mixed $value Query arg value provided by the current request.
+		 *
+		 * @return mixed|null Sanitized value ready for add_query_arg() or null if it should be dropped.
+		 */
+	private function sanitize_query_arg_value( $value ) {
+		if ( is_array( $value ) ) {
+				$sanitized = array();
+
+			foreach ( $value as $key => $item ) {
+				$item = $this->sanitize_query_arg_value( $item );
+				if ( null === $item ) {
+						continue;
+				}
+
+				if ( is_string( $key ) ) {
+						$sanitizedKey = sanitize_key( $key );
+					if ( '' === $sanitizedKey ) {
+								continue;
+					}
+
+						$sanitized[ $sanitizedKey ] = $item;
+				} else {
+						$sanitized[] = $item;
+				}
+			}
+
+				return empty( $sanitized ) ? null : $sanitized;
+		}
+
+		if ( is_scalar( $value ) ) {
+				$value = sanitize_text_field( (string) $value );
+
+				return '' === $value ? null : $value;
+		}
+
+			return null;
 	}
 }

--- a/tests/LanguageSwitcherTest.php
+++ b/tests/LanguageSwitcherTest.php
@@ -168,6 +168,63 @@ class LanguageSwitcherTest extends TestCase
         $this->assertSame('https://example.com/category/news/?paged=2&fp_lang=it', $languages['it']);
     }
 
+    public function test_append_current_query_args_sanitizes_and_filters_request_parameters(): void
+    {
+        $_GET = [
+            'fp_lang' => 'it',
+            'FP_LANG' => 'de',
+            ' foo ' => ' value ',
+            '<>' => 'should-be-removed',
+            'capsKey' => 'Value',
+            'empty' => '   ',
+            'array' => [
+                ' keep ' => '   value   ',
+                'bad key' => '<script>alert(1)</script>',
+                '<>' => 'value',
+                'nested' => [
+                    ' inner ' => ' test ',
+                    'empty' => '   ',
+                ],
+                2 => 'first',
+                3 => ['sub' => ' value '],
+            ],
+            'object' => (object) ['foo' => 'bar'],
+            'bool' => false,
+            'int' => 123,
+            'duplicate' => 'first',
+            ' Duplicate ' => 'second',
+        ];
+
+        $switcher = new LanguageSwitcher();
+        $url = $this->invokeAppendCurrentQueryArgs($switcher, 'https://example.com/post/42');
+
+        $this->assertStringStartsWith('https://example.com/post/42', $url);
+
+        $query = parse_url($url, PHP_URL_QUERY) ?? '';
+        parse_str($query, $parsed);
+
+        $this->assertSame(
+            [
+                'foo' => 'value',
+                'capskey' => 'Value',
+                'array' => [
+                    'keep' => 'value',
+                    'badkey' => '&#60;script&#62;alert(1)&#60;/script&#62;',
+                    'nested' => [
+                        'inner' => 'test',
+                    ],
+                    '0' => 'first',
+                    '1' => [
+                        'sub' => 'value',
+                    ],
+                ],
+                'int' => '123',
+                'duplicate' => 'second',
+            ],
+            $parsed
+        );
+    }
+
     private function invokeGetLanguages(LanguageSwitcher $switcher): array
     {
         $reflection = new ReflectionClass(LanguageSwitcher::class);
@@ -175,6 +232,15 @@ class LanguageSwitcherTest extends TestCase
         $method->setAccessible(true);
 
         return $method->invoke($switcher);
+    }
+
+    private function invokeAppendCurrentQueryArgs(LanguageSwitcher $switcher, string $baseUrl): string
+    {
+        $reflection = new ReflectionClass(LanguageSwitcher::class);
+        $method = $reflection->getMethod('append_current_query_args');
+        $method->setAccessible(true);
+
+        return $method->invoke($switcher, $baseUrl);
     }
 }
 }


### PR DESCRIPTION
## Summary
- guard the language switcher’s URL builder by sanitizing request keys, recursively normalizing values, and discarding empty results before appending them
- sanitize the manual string sync table name before preparing lookups so direct database reads stay compliant with WordPress coding standards

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68d532c07ae4832fa7f575c442d12bc6