### PR TITLE
Fix fatal error during plugin activation

### DIFF
--- a/fp-multilanguage/fp-multilanguage.php
+++ b/fp-multilanguage/fp-multilanguage.php
@@ -12,20 +12,22 @@
  * Domain Path: /languages
  */
 
+use FPMultilanguage\Plugin;
+
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+        exit;
 }
 
 if ( ! defined( 'FP_MULTILANGUAGE_FILE' ) ) {
-	define( 'FP_MULTILANGUAGE_FILE', __FILE__ );
+        define( 'FP_MULTILANGUAGE_FILE', __FILE__ );
 }
 
 if ( ! defined( 'FP_MULTILANGUAGE_PATH' ) ) {
-	define( 'FP_MULTILANGUAGE_PATH', plugin_dir_path( FP_MULTILANGUAGE_FILE ) );
+        define( 'FP_MULTILANGUAGE_PATH', plugin_dir_path( FP_MULTILANGUAGE_FILE ) );
 }
 
 if ( ! defined( 'FP_MULTILANGUAGE_URL' ) ) {
-	define( 'FP_MULTILANGUAGE_URL', plugin_dir_url( FP_MULTILANGUAGE_FILE ) );
+        define( 'FP_MULTILANGUAGE_URL', plugin_dir_url( FP_MULTILANGUAGE_FILE ) );
 }
 
 if ( ! defined( 'FP_MULTILANGUAGE_VERSION' ) ) {
@@ -55,12 +57,10 @@ if ( ! $is_autoloaded ) {
 	}
 }
 
-use FPMultilanguage\Plugin;
-
 if ( ! function_exists( 'fp_multilanguage' ) ) {
-	function fp_multilanguage(): Plugin {
-		return Plugin::instance();
-	}
+        function fp_multilanguage(): Plugin {
+                return Plugin::instance();
+        }
 }
 
 register_activation_hook( FP_MULTILANGUAGE_FILE, array( Plugin::class, 'activate' ) );


### PR DESCRIPTION
## Summary
- ensure the `FPMultilanguage\Plugin` import is declared before executable code to avoid syntax errors

## Testing
- php -l fp-multilanguage/fp-multilanguage.php

------
https://chatgpt.com/codex/tasks/task_e_68d66b3c1c8c832f9974871d9d833f18