### PR TITLE
Add discovery documentation for FP Multilanguage audit

### DIFF
--- a/.codex-state.json
+++ b/.codex-state.json
@@ -1,0 +1,10 @@
+{
+  "current_phase": 1,
+  "completed": [1],
+  "last_commit": "docs: discovery audit mapping",
+  "notes": [
+    "Phase 2: configure PHPCS (WordPress) and PHPStan level >=5, capture results in docs/audit/linters.txt.",
+    "Review REST endpoints for nonce coverage during security phase.",
+    "Evaluate autoload size of manual strings/log options before performance work."
+  ]
+}

--- a/docs/audit/phase-1-discovery.md
+++ b/docs/audit/phase-1-discovery.md
@@ -1,0 +1,36 @@
+# Phase 1 – Discovery Report
+
+## Scope & Methodology
+- Reviewed all PHP sources under `fp-multilanguage/`, including bootstrapping (`fp-multilanguage.php`), service container, admin UI, content/SEO managers, dynamic string filters, REST/AJAX handlers, CLI commands, installer and providers.
+- Inspected JavaScript assets in `fp-multilanguage/assets/js/` for admin, frontend and block behavior.
+- Surveyed build tooling (`composer.json`, `package.json`, `vite.config.js`), GitHub Actions workflow and existing documentation.
+- Compiled a structural overview in `docs/code-map.md` to map hooks, services, options, REST endpoints, assets and data stores.
+
+## Key Architecture Notes
+- Plugin is service-oriented around `FPMultilanguage\Plugin` with a lightweight container that wires admin settings, translation managers, SEO helpers, dynamic string handlers, logger and providers.
+- Translation data is persisted primarily in post/comment/term meta and serialized options. A custom table `{prefix}fp_multilanguage_strings` mirrors manual string metadata when available.
+- Admin UI relies on vanilla JS (no build step) to hit REST routes for settings/provider testing and on AJAX for inline manual strings.
+- Background processing is handled via a custom cron-like action `fp_multilanguage_process_translation` scheduled per post save.
+
+## Initial Findings & Potential Risks
+
+### Security & Hardening
+- REST endpoints for manual strings and translation jobs (`DynamicStrings::register_rest_routes`, `PostTranslationManager::register_rest_routes`) only rely on capability checks. When triggered from the admin UI we should also validate nonces to tighten CSRF protection during the security phase.
+- Direct database reads in `Settings\Repository::get_manual_string_metadata()` bypass `$wpdb->prepare()`. The current usage is limited to selecting static columns but still flags as a security linting concern to address.
+
+### Performance & Scalability
+- `DynamicStrings::enqueue_assets()` unconditionally enqueues both `dynamic-translations.js` and `frontend.js` on every admin and frontend page load, even for anonymous visitors. We should gate these enqueues to the pages that actually need manual string editing to avoid unnecessary requests.
+- Manual string catalogs, logs and other large arrays are stored in autoloaded options (`fp_multilanguage_manual_strings`, `fp_multilanguage_logs`). This can bloat the `autoload` cache on large sites; we should evaluate migrating heavy datasets to non-autoloaded storage or the dedicated custom table.
+- Translation jobs schedule a new single event five seconds after each save. There is clearing logic, but we should confirm there are no race conditions or duplicate cron entries under high frequency updates.
+
+### Compatibility & Code Quality
+- The codebase assumes PHP 7.4+ (typed properties). We need to document/verify minimum version requirements and test compatibility with current WordPress releases.
+- Several modules (`DynamicStrings`, `PostTranslationManager`, `SEO`) hook into numerous filters; we will need targeted linting/static analysis to ensure no deprecated hooks/functions are used.
+
+### Testing & Tooling Gaps
+- No automated linting or testing workflows are configured beyond a packaging GitHub Action. We will introduce PHPCS/PHPStan and PHPUnit/CI in later phases.
+- There is no runtime diagnostic logging surfaced for development environments; adding a temporary logger in Phase 3 will help capture notices/warnings.
+
+## Next Steps
+- Proceed to Phase 2 (Linters): set up PHPCS (WordPress standards) and PHPStan (>= level 5), fix auto-fixable issues and capture results in `docs/audit/linters.txt`.
+- Continue to update `.codex-state.json` after each phase with status, commits and outstanding notes.

--- a/docs/code-map.md
+++ b/docs/code-map.md
@@ -1,0 +1,84 @@
+# FP Multilanguage – Code Map
+
+## Overview
+FP Multilanguage is a WordPress plugin that provides automatic and manual translations for posts, attachments, comments, terms and dynamic strings. The plugin bootstraps through a dependency container and exposes admin pages, REST endpoints, a shortcode, widgets, a Gutenberg block, CLI commands and background jobs to keep translations in sync. Key constants (`FP_MULTILANGUAGE_FILE`, `FP_MULTILANGUAGE_PATH`, `FP_MULTILANGUAGE_URL`, `FP_MULTILANGUAGE_VERSION`) are defined in `fp-multilanguage.php` and used throughout the codebase.
+
+## Bootstrap & Service Container
+- **Main entry (`fp-multilanguage/fp-multilanguage.php`)**: Loads Composer or fallback autoloader, registers activation/deactivation/uninstall hooks and boots the singleton `FPMultilanguage\Plugin`.
+- **`FPMultilanguage\Plugin`**: Builds a `Support\Container`, registers services and hooks:
+  - Hooks: `plugins_loaded` → `bootstrap`, `init` → load textdomain, `template_redirect` → remember language cookie, `widgets_init` → register widgets, `add_shortcode` for `[fp_language_switcher]`.
+  - Activation triggers migrations/default settings (`Install\Migrator`, `Admin\Settings::bootstrap_defaults()`).
+  - `bootstrap()` resolves services and calls their `register()` methods.
+
+## Admin Interfaces (`includes/Admin`)
+- **`Settings`**: Registers admin menu pages (main settings, onboarding, log viewer, manual strings), WP Settings API fields, enqueues admin scripts/styles and binds `admin_post_fp_multilanguage_save_strings`. Bootstraps `SettingsRestController` REST routes and wires repository cache hooks.
+- **`Settings\Repository`**: Handles option storage, sanitization and caching. Manages manual string catalogs, provider credentials, translatable entities, quote tracking, etc. Uses option names `fp_multilanguage_options`, `fp_multilanguage_manual_strings` and the legacy cache option `fp_multilanguage_strings`, and exposes defaults.
+- **`Settings\ManualStringsUI`**: Renders manual string editor table and handles POST saving (`manage_options` + nonce required).
+- **`Settings\RestController`**: Registers REST namespace `fp-multilanguage/v1` for `/settings` CRUD and `/providers/test`. Requires `manage_options` capability and verifies nonce (`fp_multilanguage_settings`).
+- **`AdminNotices`**: Collects transient admin notices (info/warning/error) and renders them in `admin_notices` hook.
+
+## Content Translation (`includes/Content`)
+- **`PostTranslationManager`**:
+  - Hooks: `init` (registers `fp_lang` query var), `save_post` (queues translation job), `rest_api_init` (registers translation routes), scheduled event `fp_multilanguage_process_translation`, filters for `the_content`, `the_title`, `get_the_excerpt`, attachment metadata and `body_class` to inject localized values.
+  - REST endpoints under `/posts/{id}/translate`, `/attachments/{id}/translate`, `/content/{type}/{id}/translate` (POST). Permission requires `current_user_can( 'edit_post', $id )`.
+  - Stores translations in post meta `_fp_multilanguage_translations` and relationship metadata `_fp_multilanguage_relations`.
+  - Schedules background jobs with `wp_schedule_single_event` and can process synchronously.
+- **`CommentTranslationManager`**: Hooks `wp_insert_comment`, `edit_comment`, `deleted_comment` to sync comment translations into comment meta `_fp_multilanguage_comment_translations`.
+- **`TermTranslationManager`**: Hooks `created_term`, `edited_term`, `delete_term` to manage term meta `_fp_multilanguage_term_translations` and relationships.
+
+## Dynamic Strings (`includes/Dynamic`)
+- **`DynamicStrings`**:
+  - Hooks: `init` (register assets), `wp_enqueue_scripts` & `admin_enqueue_scripts` (enqueue JS), AJAX `wp_ajax_fp_multilanguage_save_string`, REST `/strings` endpoints, filters `gettext`, `ngettext`, `gettext_with_context`, widget/title/nav menu/thememod filters to capture and translate arbitrary strings.
+  - Maintains runtime caches and interacts with manual string options.
+  - AJAX requests require nonce `fp_multilanguage_manual_string` and `manage_options` capability.
+
+## SEO Module (`includes/SEO/SEO.php`)
+- Registers meta box (`add_meta_boxes`), handles `save_post` to persist SEO translations, cleans up on `delete_post`, and renders hreflang/canonical/open graph tags via `wp_head`. Stores language-specific slugs in option `fp_multilanguage_slug_index`.
+
+## Widgets, Shortcodes & Blocks
+- **Widget**: `Widgets\LanguageSwitcher` extends `WP_Widget`; provides frontend switcher markup and admin form.
+- **Shortcode**: `[fp_language_switcher]` delegates to `LanguageSwitcher::render_shortcode()`.
+- **Block**: `Blocks\LanguageSwitcherBlock` registers a dynamic block via `register_block_type` with JS from `assets/js/language-switcher-block.js`.
+
+## Services & Support
+- **`Services\TranslationService`**: Central translation engine with caching (object cache + transients), provider failover, manual overrides and quota tracking (`fp_multilanguage_quota`). Flushes cache by bumping `fp_multilanguage_cache_version`.
+- **Providers**: `GoogleProvider`, `DeepLProvider` implement `TranslationProviderInterface`. They perform remote API calls using WordPress HTTP API with configurable options.
+- **`Services\Logger`**: Writes to WooCommerce logger or PHP error log, mirrors entries into option `fp_multilanguage_logs` (latest 200). CLI aware.
+- **`Support\Container`**: Lightweight dependency container used by `Plugin`.
+- **`CurrentLanguage`**: Resolves current language via query param, cookie, user meta, locale or path. Persists preference via cookie/user meta.
+
+## CLI & Tools
+- **`CLI\Commands`**: Registers `wp fp-multilanguage translate <post_id> [--language=<code>]` when WP-CLI is available.
+- **`Services\Logger`** exposes stored log entries for admin log page.
+
+## Install & Database
+- **`Install\Migrator`**: Creates table `{prefix}fp_multilanguage_strings` for manual string storage (`maybe_create_table`) and tracks DB version option `fp_multilanguage_db_version`. Drops table on uninstall.
+
+## Assets & Build
+- Source JS located in `assets/js/` (admin interface, frontend dynamic translations, block). Pre-built bundles in `assets/dist/`. Build tooling via Vite (`vite.config.js`) and npm scripts (`package.json`).
+
+## Localization
+- Text domain `fp-multilanguage`. MO/PO files expected under `languages/`. `Plugin::load_textdomain()` loads translations on `init`.
+
+## Stored Options & Meta Overview
+- Options: `fp_multilanguage_options`, `fp_multilanguage_manual_strings`, `fp_multilanguage_strings` (legacy metadata cache), `fp_multilanguage_version`, `fp_multilanguage_db_version`, `fp_multilanguage_quota`, `fp_multilanguage_slug_index`, `fp_multilanguage_logs`, `fp_multilanguage_cache_version`.
+- Post Meta: `_fp_multilanguage_translations`, `_fp_multilanguage_relations`, `_fp_multilanguage_seo` (per SEO module).
+- Comment Meta: `_fp_multilanguage_comment_translations`.
+- Term Meta: `_fp_multilanguage_term_translations`.
+
+## REST API Summary
+- `fp-multilanguage/v1/settings` (GET/POST) – admin settings CRUD with nonce & `manage_options`.
+- `fp-multilanguage/v1/providers/test` (POST) – provider credential tester.
+- `fp-multilanguage/v1/strings` (GET/POST) – manual string management (requires `manage_options`).
+- `fp-multilanguage/v1/posts/{id}/translate` (POST) – queue/sync translations for a post.
+- `fp-multilanguage/v1/attachments/{id}/translate` (POST) – queue/sync attachment translations.
+- `fp-multilanguage/v1/content/{type}/{id}/translate` (POST) – generic entry point for custom post types.
+
+## Cron & Background Jobs
+- Custom action `fp_multilanguage_process_translation` scheduled via `wp_schedule_single_event` for asynchronous translation tasks.
+
+## Frontend Integration
+- Filters for content/title/excerpt/meta ensure translated strings are displayed.
+- `LanguageSwitcher` widget/shortcode/block output localized navigation.
+- Dynamic script attaches to DOM elements with `data-fp-translatable` for manual override capture.
+


### PR DESCRIPTION
## Summary
- document the plugin architecture, hooks, options, endpoints, and assets in docs/code-map.md
- capture phase 1 discovery findings and risks in docs/audit/phase-1-discovery.md
- initialize .codex-state.json to track audit progress and upcoming tasks

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d699e938a0832fbd3d78d9dbaac210