### PR TITLE
Prepare FP Multilanguage 0.2.1 release

### DIFF
--- a/fp-multilanguage/admin/class-admin.php
+++ b/fp-multilanguage/admin/class-admin.php
@@ -1,0 +1,785 @@
+<?php
+/**
+ * Admin UI controller.
+ *
+ * @package FP_Multilanguage
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+exit;
+}
+
+/**
+ * Manage admin screens and settings forms.
+ *
+ * @since 0.2.0
+ */
+class FPML_Admin {
+/**
+ * Settings instance.
+ *
+ * @var FPML_Settings
+ */
+    protected $settings;
+
+    /**
+     * Strings scanner instance.
+     *
+     * @var FPML_Strings_Scanner
+     */
+    protected $scanner;
+
+    /**
+     * Strings override manager.
+     *
+     * @var FPML_Strings_Override
+     */
+    protected $overrides;
+
+    /**
+     * Glossary manager.
+     *
+     * @var FPML_Glossary
+     */
+    protected $glossary;
+
+    /**
+     * Export/import helper.
+     *
+     * @var FPML_Export_Import
+     */
+    protected $exporter;
+
+    /**
+     * Plugin instance.
+     *
+     * @var FPML_Plugin
+     */
+    protected $plugin;
+
+/**
+ * Menu slug.
+ */
+const MENU_SLUG = 'fpml-settings';
+
+/**
+ * Constructor.
+ */
+        public function __construct() {
+                $this->settings  = FPML_Settings::instance();
+                $this->scanner   = FPML_Strings_Scanner::instance();
+                $this->overrides = FPML_Strings_Override::instance();
+                $this->glossary  = FPML_Glossary::instance();
+                $this->exporter  = FPML_Export_Import::instance();
+                $this->plugin    = FPML_Plugin::instance();
+
+                add_action( 'admin_menu', array( $this, 'register_menu' ) );
+                add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
+                add_action( 'admin_notices', array( $this, 'maybe_render_cron_notice' ) );
+                add_action( 'admin_post_fpml_scan_strings', array( $this, 'handle_scan_strings' ) );
+        add_action( 'admin_post_fpml_save_overrides', array( $this, 'handle_save_overrides' ) );
+        add_action( 'admin_post_fpml_import_overrides', array( $this, 'handle_import_overrides' ) );
+        add_action( 'admin_post_fpml_export_overrides', array( $this, 'handle_export_overrides' ) );
+        add_action( 'admin_post_fpml_save_glossary', array( $this, 'handle_save_glossary' ) );
+        add_action( 'admin_post_fpml_import_glossary', array( $this, 'handle_import_glossary' ) );
+        add_action( 'admin_post_fpml_export_glossary', array( $this, 'handle_export_glossary' ) );
+        add_action( 'admin_post_fpml_export_state', array( $this, 'handle_export_state' ) );
+        add_action( 'admin_post_fpml_import_state', array( $this, 'handle_import_state' ) );
+        add_action( 'admin_post_fpml_export_logs', array( $this, 'handle_export_logs' ) );
+        add_action( 'admin_post_fpml_import_logs', array( $this, 'handle_import_logs' ) );
+        add_action( 'admin_post_fpml_clear_sandbox', array( $this, 'handle_clear_sandbox' ) );
+    }
+
+/**
+ * Register admin menu.
+ *
+ * @since 0.2.0
+ *
+ * @return void
+ */
+public function register_menu() {
+add_menu_page(
+esc_html__( 'FP Multilanguage', 'fp-multilanguage' ),
+esc_html__( 'FP Multilanguage', 'fp-multilanguage' ),
+'manage_options',
+self::MENU_SLUG,
+array( $this, 'render_settings_page' ),
+'dashicons-translation',
+58
+);
+}
+
+/**
+ * Enqueue admin assets.
+ *
+ * @since 0.2.0
+ *
+ * @param string $hook Current admin page hook.
+ *
+ * @return void
+ */
+public function enqueue_assets( $hook ) {
+if ( 'toplevel_page_' . self::MENU_SLUG !== $hook ) {
+return;
+}
+
+wp_enqueue_style( 'fpml-admin', FPML_PLUGIN_URL . 'assets/admin.css', array(), FPML_PLUGIN_VERSION );
+wp_enqueue_script( 'fpml-admin', FPML_PLUGIN_URL . 'assets/admin.js', array(), FPML_PLUGIN_VERSION, true );
+}
+
+/**
+ * Render settings page.
+ *
+ * @since 0.2.0
+ *
+ * @return void
+ */
+public function render_settings_page() {
+        if ( ! current_user_can( 'manage_options' ) ) {
+                return;
+        }
+
+        $tabs        = $this->get_tabs();
+        $current_tab = isset( $_GET['tab'] ) ? sanitize_key( wp_unslash( $_GET['tab'] ) ) : 'general'; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+        if ( ! isset( $tabs[ $current_tab ] ) ) {
+                $current_tab = 'general';
+        }
+
+        $view_file = FPML_PLUGIN_DIR . 'admin/views/' . $tabs[ $current_tab ]['view'];
+
+        $options   = $this->settings->all();
+        $scanner   = $this->scanner;
+        $overrides = $this->overrides;
+        $glossary  = $this->glossary;
+        $exporter  = $this->exporter;
+        $plugin    = $this->plugin instanceof FPML_Plugin ? $this->plugin : FPML_Plugin::instance();
+        $diagnostics_snapshot = array();
+
+        if ( 'diagnostics' === $current_tab ) {
+                $diagnostics_snapshot = $plugin->get_diagnostics_snapshot();
+        }
+
+        echo '<div class="wrap fpml-settings-wrap">';
+        echo '<h1>' . esc_html__( 'FP Multilanguage', 'fp-multilanguage' ) . '</h1>';
+        settings_errors( 'fpml_settings_group' );
+
+        if ( $plugin->is_assisted_mode() ) {
+                $reason_label = $plugin->get_assisted_reason_label();
+                $reason_suffix = '' !== $reason_label ? sprintf( ' (%s)', $reason_label ) : '';
+
+                echo '<div class="notice notice-info">';
+                echo '<p>' . esc_html__( 'Modalità assistita attiva: WPML/Polylang gestiscono routing e duplicazione. FP Multilanguage fornisce solo strumenti di traduzione.', 'fp-multilanguage' ) . esc_html( $reason_suffix ) . '</p>';
+                echo '</div>';
+        }
+
+        echo '<nav class="nav-tab-wrapper fpml-settings-tabs">';
+
+        foreach ( $tabs as $tab_key => $tab_data ) {
+                $url   = add_query_arg( array( 'page' => self::MENU_SLUG, 'tab' => $tab_key ), admin_url( 'admin.php' ) );
+                $class = 'nav-tab' . ( $tab_key === $current_tab ? ' nav-tab-active' : '' );
+                echo '<a class="' . esc_attr( $class ) . '" href="' . esc_url( $url ) . '">' . esc_html( $tab_data['label'] ) . '</a>';
+        }
+
+        echo '</nav>';
+
+        if ( file_exists( $view_file ) ) {
+                $settings = $this->settings;
+                require $view_file;
+        } else {
+                echo '<p>' . esc_html__( 'Vista non disponibile.', 'fp-multilanguage' ) . '</p>';
+        }
+
+        echo '</div>';
+}
+
+/**
+ * Get tab definitions.
+ *
+ * @since 0.2.0
+ *
+ * @return array
+ */
+protected function get_tabs() {
+        return array(
+'general'     => array(
+'label' => esc_html__( 'Generale', 'fp-multilanguage' ),
+'view'  => 'settings-general.php',
+),
+'content'     => array(
+'label' => esc_html__( 'Contenuti', 'fp-multilanguage' ),
+'view'  => 'settings-content.php',
+),
+'seo'         => array(
+'label' => esc_html__( 'SEO', 'fp-multilanguage' ),
+'view'  => 'settings-seo.php',
+),
+'strings'     => array(
+'label' => esc_html__( 'Stringhe', 'fp-multilanguage' ),
+'view'  => 'settings-strings.php',
+),
+'glossary'    => array(
+'label' => esc_html__( 'Glossario', 'fp-multilanguage' ),
+'view'  => 'settings-glossary.php',
+),
+'export'      => array(
+'label' => esc_html__( 'Export / Import', 'fp-multilanguage' ),
+'view'  => 'settings-export.php',
+),
+'diagnostics' => array(
+'label' => esc_html__( 'Diagnostica', 'fp-multilanguage' ),
+'view'  => 'settings-diagnostics.php',
+),
+        );
+    }
+
+    /**
+     * Handle string scan requests.
+     *
+     * @since 0.2.0
+     *
+     * @return void
+     */
+    public function handle_scan_strings() {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_die( esc_html__( 'Permessi insufficienti.', 'fp-multilanguage' ) );
+        }
+
+        check_admin_referer( 'fpml_scan_strings' );
+
+        $count = $this->scanner->scan();
+
+        add_settings_error(
+            'fpml_settings_group',
+            'fpml-scan-strings',
+            sprintf(
+                /* translators: %d: total detected strings */
+                esc_html__( 'Scansione completata: rilevate %d stringhe.', 'fp-multilanguage' ),
+                absint( $count )
+            ),
+            'updated'
+        );
+
+        $this->redirect_to_tab( 'strings' );
+    }
+
+    /**
+     * Handle override save requests.
+     *
+     * @since 0.2.0
+     *
+     * @return void
+     */
+    public function handle_save_overrides() {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_die( esc_html__( 'Permessi insufficienti.', 'fp-multilanguage' ) );
+        }
+
+        check_admin_referer( 'fpml_save_overrides' );
+
+        $raw_overrides = isset( $_POST['overrides'] ) ? wp_unslash( $_POST['overrides'] ) : array(); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+        $payload       = array();
+
+        if ( is_array( $raw_overrides ) ) {
+            foreach ( $raw_overrides as $hash => $data ) {
+                $hash = sanitize_key( $hash );
+
+                if ( '' === $hash ) {
+                    continue;
+                }
+
+                $payload[ $hash ] = array(
+                    'target'  => isset( $data['target'] ) ? sanitize_text_field( wp_unslash( $data['target'] ) ) : '',
+                    'context' => isset( $data['context'] ) ? sanitize_text_field( wp_unslash( $data['context'] ) ) : '',
+                    'delete'  => ! empty( $data['delete'] ),
+                );
+            }
+        }
+
+        if ( ! empty( $payload ) ) {
+            $this->overrides->update_overrides( $payload );
+        }
+
+        $new_source  = isset( $_POST['new_source'] ) ? sanitize_text_field( wp_unslash( $_POST['new_source'] ) ) : '';
+        $new_target  = isset( $_POST['new_target'] ) ? sanitize_text_field( wp_unslash( $_POST['new_target'] ) ) : '';
+        $new_context = isset( $_POST['new_context'] ) ? sanitize_text_field( wp_unslash( $_POST['new_context'] ) ) : '';
+
+        if ( '' !== $new_source && '' !== $new_target ) {
+            $this->overrides->add_override( $new_source, $new_target, $new_context );
+        }
+
+        add_settings_error(
+            'fpml_settings_group',
+            'fpml-save-overrides',
+            esc_html__( 'Override aggiornate.', 'fp-multilanguage' ),
+            'updated'
+        );
+
+        $this->redirect_to_tab( 'strings' );
+    }
+
+    /**
+     * Handle overrides import requests.
+     *
+     * @since 0.2.0
+     *
+     * @return void
+     */
+    public function handle_import_overrides() {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_die( esc_html__( 'Permessi insufficienti.', 'fp-multilanguage' ) );
+        }
+
+        check_admin_referer( 'fpml_import_overrides' );
+
+        $format  = isset( $_POST['format'] ) ? sanitize_key( wp_unslash( $_POST['format'] ) ) : 'json';
+        $payload = isset( $_POST['payload'] ) ? wp_unslash( $_POST['payload'] ) : ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+        $payload = wp_check_invalid_utf8( $payload, true );
+        $payload = is_string( $payload ) ? trim( $payload ) : '';
+
+        $imported = 0;
+
+        if ( 'csv' === $format ) {
+            $imported = $this->overrides->import_csv( $payload );
+        } else {
+            $imported = $this->overrides->import_json( $payload );
+        }
+
+        add_settings_error(
+            'fpml_settings_group',
+            'fpml-import-overrides',
+            sprintf(
+                /* translators: %d: number of imported overrides */
+                esc_html__( 'Import completato: %d override caricate.', 'fp-multilanguage' ),
+                absint( $imported )
+            ),
+            'updated'
+        );
+
+        $this->redirect_to_tab( 'strings' );
+    }
+
+    /**
+     * Output overrides export payload.
+     *
+     * @since 0.2.0
+     *
+     * @return void
+     */
+    public function handle_export_overrides() {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_die( esc_html__( 'Permessi insufficienti.', 'fp-multilanguage' ) );
+        }
+
+        check_admin_referer( 'fpml_export_overrides' );
+
+        $format = isset( $_POST['format'] ) ? sanitize_key( wp_unslash( $_POST['format'] ) ) : 'json';
+        $format = in_array( $format, array( 'json', 'csv' ), true ) ? $format : 'json';
+
+        nocache_headers();
+
+        if ( 'csv' === $format ) {
+            header( 'Content-Type: text/csv; charset=utf-8' );
+            header( 'Content-Disposition: attachment; filename=fpml-string-overrides.csv' );
+            echo $this->overrides->export_csv(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+        } else {
+            header( 'Content-Type: application/json; charset=utf-8' );
+            header( 'Content-Disposition: attachment; filename=fpml-string-overrides.json' );
+            echo $this->overrides->export_json(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+        }
+
+        exit;
+    }
+
+    /**
+     * Handle glossary save requests.
+     *
+     * @since 0.2.0
+     *
+     * @return void
+     */
+    public function handle_save_glossary() {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_die( esc_html__( 'Permessi insufficienti.', 'fp-multilanguage' ) );
+        }
+
+        check_admin_referer( 'fpml_save_glossary' );
+
+        $raw_entries = isset( $_POST['entries'] ) ? wp_unslash( $_POST['entries'] ) : array(); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+        $to_save     = array();
+
+        if ( is_array( $raw_entries ) ) {
+            foreach ( $raw_entries as $key => $data ) {
+                $key = sanitize_key( $key );
+
+                if ( '' === $key ) {
+                    continue;
+                }
+
+                if ( ! empty( $data['delete'] ) ) {
+                    $to_save[ $key ] = array( 'delete' => true );
+                    continue;
+                }
+
+                $to_save[ $key ] = array(
+                    'source'  => isset( $data['source'] ) ? sanitize_text_field( wp_unslash( $data['source'] ) ) : '',
+                    'target'  => isset( $data['target'] ) ? sanitize_text_field( wp_unslash( $data['target'] ) ) : '',
+                    'context' => isset( $data['context'] ) ? sanitize_text_field( wp_unslash( $data['context'] ) ) : '',
+                );
+            }
+        }
+
+        if ( ! empty( $to_save ) ) {
+            $delete = array();
+            $keep   = array();
+
+            foreach ( $to_save as $hash => $entry ) {
+                if ( isset( $entry['delete'] ) && $entry['delete'] ) {
+                    $delete[] = $hash;
+                    continue;
+                }
+
+                if ( '' !== $entry['source'] && '' !== $entry['target'] ) {
+                    $keep[] = array(
+                        'hash'    => $hash,
+                        'source'  => $entry['source'],
+                        'target'  => $entry['target'],
+                        'context' => $entry['context'],
+                    );
+                }
+            }
+
+            if ( ! empty( $delete ) ) {
+                $this->glossary->delete_entries( $delete );
+            }
+
+            if ( ! empty( $keep ) ) {
+                foreach ( $keep as $entry ) {
+                    $new_hash = md5( wp_json_encode( array( $entry['source'], $entry['context'] ) ) );
+
+                    if ( $new_hash !== $entry['hash'] ) {
+                        $this->glossary->delete_entries( array( $entry['hash'] ) );
+                    }
+
+                    $this->glossary->upsert_entry( $entry['source'], $entry['target'], $entry['context'] );
+                }
+            }
+        }
+
+        $new_source  = isset( $_POST['new_glossary_source'] ) ? sanitize_text_field( wp_unslash( $_POST['new_glossary_source'] ) ) : '';
+        $new_target  = isset( $_POST['new_glossary_target'] ) ? sanitize_text_field( wp_unslash( $_POST['new_glossary_target'] ) ) : '';
+        $new_context = isset( $_POST['new_glossary_context'] ) ? sanitize_text_field( wp_unslash( $_POST['new_glossary_context'] ) ) : '';
+
+        if ( '' !== $new_source && '' !== $new_target ) {
+            $this->glossary->upsert_entry( $new_source, $new_target, $new_context );
+        }
+
+        add_settings_error(
+            'fpml_settings_group',
+            'fpml-save-glossary',
+            esc_html__( 'Glossario aggiornato.', 'fp-multilanguage' ),
+            'updated'
+        );
+
+        $this->redirect_to_tab( 'glossary' );
+    }
+
+    /**
+     * Handle glossary import.
+     *
+     * @since 0.2.0
+     *
+     * @return void
+     */
+    public function handle_import_glossary() {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_die( esc_html__( 'Permessi insufficienti.', 'fp-multilanguage' ) );
+        }
+
+        check_admin_referer( 'fpml_import_glossary' );
+
+        $format  = isset( $_POST['format'] ) ? sanitize_key( wp_unslash( $_POST['format'] ) ) : 'json';
+        $payload = isset( $_POST['payload'] ) ? wp_unslash( $_POST['payload'] ) : ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+        $payload = wp_check_invalid_utf8( $payload, true );
+        $payload = is_string( $payload ) ? trim( $payload ) : '';
+
+        $imported = 0;
+
+        if ( 'csv' === $format ) {
+            $imported = $this->glossary->import_csv( $payload );
+        } else {
+            $imported = $this->glossary->import_json( $payload );
+        }
+
+        add_settings_error(
+            'fpml_settings_group',
+            'fpml-import-glossary',
+            sprintf(
+                /* translators: %d: number of imported glossary entries */
+                esc_html__( 'Import glossario completato: %d voci caricate.', 'fp-multilanguage' ),
+                absint( $imported )
+            ),
+            'updated'
+        );
+
+        $this->redirect_to_tab( 'glossary' );
+    }
+
+    /**
+     * Export glossary payload.
+     *
+     * @since 0.2.0
+     *
+     * @return void
+     */
+    public function handle_export_glossary() {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_die( esc_html__( 'Permessi insufficienti.', 'fp-multilanguage' ) );
+        }
+
+        check_admin_referer( 'fpml_export_glossary' );
+
+        $format = isset( $_POST['format'] ) ? sanitize_key( wp_unslash( $_POST['format'] ) ) : 'json';
+        $format = in_array( $format, array( 'json', 'csv' ), true ) ? $format : 'json';
+
+        nocache_headers();
+
+        if ( 'csv' === $format ) {
+            header( 'Content-Type: text/csv; charset=utf-8' );
+            header( 'Content-Disposition: attachment; filename=fpml-glossary.csv' );
+            echo $this->glossary->export_csv(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+        } else {
+            header( 'Content-Type: application/json; charset=utf-8' );
+            header( 'Content-Disposition: attachment; filename=fpml-glossary.json' );
+            echo $this->glossary->export_json(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+        }
+
+        exit;
+    }
+
+    /**
+     * Export translation state payload.
+     *
+     * @since 0.2.0
+     *
+     * @return void
+     */
+    public function handle_export_state() {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_die( esc_html__( 'Permessi insufficienti.', 'fp-multilanguage' ) );
+        }
+
+        check_admin_referer( 'fpml_export_state' );
+
+        $format = isset( $_POST['format'] ) ? sanitize_key( wp_unslash( $_POST['format'] ) ) : 'json';
+        $format = in_array( $format, array( 'json', 'csv' ), true ) ? $format : 'json';
+
+        nocache_headers();
+
+        if ( 'csv' === $format ) {
+            header( 'Content-Type: text/csv; charset=utf-8' );
+            header( 'Content-Disposition: attachment; filename=fpml-translation-state.csv' );
+        } else {
+            header( 'Content-Type: application/json; charset=utf-8' );
+            header( 'Content-Disposition: attachment; filename=fpml-translation-state.json' );
+        }
+
+        echo $this->exporter->export_translation_state( $format ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+        exit;
+    }
+
+    /**
+     * Import translation state payload.
+     *
+     * @since 0.2.0
+     *
+     * @return void
+     */
+    public function handle_import_state() {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_die( esc_html__( 'Permessi insufficienti.', 'fp-multilanguage' ) );
+        }
+
+        check_admin_referer( 'fpml_import_state' );
+
+        $format  = isset( $_POST['format'] ) ? sanitize_key( wp_unslash( $_POST['format'] ) ) : 'json';
+        $payload = isset( $_POST['payload'] ) ? wp_unslash( $_POST['payload'] ) : ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+        $payload = wp_check_invalid_utf8( $payload, true );
+        $payload = is_string( $payload ) ? trim( $payload ) : '';
+
+        $imported = $this->exporter->import_translation_state( $payload, $format );
+
+        add_settings_error(
+            'fpml_settings_group',
+            'fpml-import-state',
+            sprintf(
+                /* translators: %d: number of imported rows */
+                esc_html__( 'Import stato traduzioni completato: %d righe aggiornate.', 'fp-multilanguage' ),
+                absint( $imported )
+            ),
+            'updated'
+        );
+
+        $this->redirect_to_tab( 'export' );
+    }
+
+    /**
+     * Export logger payload.
+     *
+     * @since 0.2.0
+     *
+     * @return void
+     */
+    public function handle_export_logs() {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_die( esc_html__( 'Permessi insufficienti.', 'fp-multilanguage' ) );
+        }
+
+        check_admin_referer( 'fpml_export_logs' );
+
+        $format = isset( $_POST['format'] ) ? sanitize_key( wp_unslash( $_POST['format'] ) ) : 'json';
+        $format = in_array( $format, array( 'json', 'csv' ), true ) ? $format : 'json';
+
+        nocache_headers();
+
+        if ( 'csv' === $format ) {
+            header( 'Content-Type: text/csv; charset=utf-8' );
+            header( 'Content-Disposition: attachment; filename=fpml-logs.csv' );
+        } else {
+            header( 'Content-Type: application/json; charset=utf-8' );
+            header( 'Content-Disposition: attachment; filename=fpml-logs.json' );
+        }
+
+        echo $this->exporter->export_logs( $format ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+        exit;
+    }
+
+    /**
+     * Import logger payload.
+     *
+     * @since 0.2.0
+     *
+     * @return void
+     */
+    public function handle_import_logs() {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_die( esc_html__( 'Permessi insufficienti.', 'fp-multilanguage' ) );
+        }
+
+        check_admin_referer( 'fpml_import_logs' );
+
+        $format  = isset( $_POST['format'] ) ? sanitize_key( wp_unslash( $_POST['format'] ) ) : 'json';
+        $payload = isset( $_POST['payload'] ) ? wp_unslash( $_POST['payload'] ) : ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+        $payload = wp_check_invalid_utf8( $payload, true );
+        $payload = is_string( $payload ) ? trim( $payload ) : '';
+
+        $imported = $this->exporter->import_logs( $payload, $format );
+
+        add_settings_error(
+            'fpml_settings_group',
+            'fpml-import-logs',
+            sprintf(
+                /* translators: %d: number of imported log rows */
+                esc_html__( 'Import log completato: %d eventi registrati.', 'fp-multilanguage' ),
+                absint( $imported )
+            ),
+            'updated'
+        );
+
+        $this->redirect_to_tab( 'export' );
+    }
+
+    /**
+     * Clear sandbox previews.
+     *
+     * @since 0.2.0
+     *
+     * @return void
+     */
+    public function handle_clear_sandbox() {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_die( esc_html__( 'Permessi insufficienti.', 'fp-multilanguage' ) );
+        }
+
+        check_admin_referer( 'fpml_clear_sandbox' );
+
+        $this->exporter->clear_sandbox_previews();
+
+        add_settings_error(
+            'fpml_settings_group',
+            'fpml-clear-sandbox',
+            esc_html__( 'Anteprime sandbox azzerate.', 'fp-multilanguage' ),
+            'updated'
+        );
+
+        $this->redirect_to_tab( 'export' );
+    }
+
+    /**
+     * Display a notice when WP-Cron is disabled.
+     *
+     * @since 0.2.0
+     *
+     * @return void
+     */
+    public function maybe_render_cron_notice() {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            return;
+        }
+
+        if ( $this->plugin instanceof FPML_Plugin && $this->plugin->is_assisted_mode() ) {
+            return;
+        }
+
+        if ( ! defined( 'DISABLE_WP_CRON' ) || ! DISABLE_WP_CRON ) {
+            return;
+        }
+
+        if ( ! function_exists( 'get_current_screen' ) ) {
+            return;
+        }
+
+        $screen = get_current_screen();
+
+        if ( ! $screen || 'toplevel_page_' . self::MENU_SLUG !== $screen->id ) {
+            return;
+        }
+
+        $path    = untrailingslashit( ABSPATH );
+        $command = sprintf( "*/5 * * * * cd '%1\$s' && wp cron event run --due-now >/dev/null 2>&1", $path );
+
+        echo '<div class="notice notice-warning">';
+        echo '<p>' . esc_html__( 'WP-Cron risulta disabilitato (DISABLE_WP_CRON = true). Configura un cron di sistema per mantenere attiva la coda di traduzione.', 'fp-multilanguage' ) . '</p>';
+        echo '<p>' . esc_html__( 'Esempio crontab (ogni 5 minuti con WP-CLI):', 'fp-multilanguage' ) . '</p>';
+        echo '<p><code>' . esc_html( $command ) . '</code></p>';
+
+        $php_command = sprintf( "*/5 * * * * php '%1\$s/wp-cron.php' >/dev/null 2>&1", $path );
+
+        echo '<p>' . esc_html__( 'In alternativa puoi schedulare direttamente wp-cron.php:', 'fp-multilanguage' ) . '</p>';
+        echo '<p><code>' . esc_html( $php_command ) . '</code></p>';
+        echo '</div>';
+    }
+
+    /**
+     * Redirect back to a specific settings tab.
+     *
+     * @since 0.2.0
+     *
+     * @param string $tab Tab slug.
+     *
+     * @return void
+     */
+    protected function redirect_to_tab( $tab ) {
+        $tab = sanitize_key( $tab );
+        $url = add_query_arg(
+            array(
+                'page' => self::MENU_SLUG,
+                'tab'  => $tab,
+            ),
+            admin_url( 'admin.php' )
+        );
+
+        wp_safe_redirect( $url );
+        exit;
+    }
+}

--- a/fp-multilanguage/admin/views/settings-content.php
+++ b/fp-multilanguage/admin/views/settings-content.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Content settings view.
+ *
+ * @package FP_Multilanguage
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+exit;
+}
+
+$options = isset( $options ) ? $options : array();
+?>
+<form method="post" action="<?php echo esc_url( admin_url( 'options.php' ) ); ?>">
+<?php settings_fields( 'fpml_settings_group' ); ?>
+<table class="form-table" role="presentation">
+<tbody>
+<tr>
+<th scope="row"><?php esc_html_e( 'Dimensione batch', 'fp-multilanguage' ); ?></th>
+<td>
+<input type="number" min="1" class="small-text" name="<?php echo esc_attr( FPML_Settings::OPTION_KEY ); ?>[batch_size]" value="<?php echo esc_attr( $options['batch_size'] ); ?>" />
+<p class="fpml-field-description"><?php esc_html_e( 'Numero di elementi processati per ciclo cron (post, termini, stringhe).', 'fp-multilanguage' ); ?></p>
+</td>
+</tr>
+<tr>
+<th scope="row"><?php esc_html_e( 'Max caratteri per richiesta', 'fp-multilanguage' ); ?></th>
+<td>
+<input type="number" min="500" class="small-text" name="<?php echo esc_attr( FPML_Settings::OPTION_KEY ); ?>[max_chars]" value="<?php echo esc_attr( $options['max_chars'] ); ?>" />
+<p class="fpml-field-description"><?php esc_html_e( 'Limite per chunk inviato al provider (consigliato 4500).', 'fp-multilanguage' ); ?></p>
+</td>
+</tr>
+<tr>
+<th scope="row"><?php esc_html_e( 'Frequenza cron', 'fp-multilanguage' ); ?></th>
+<td>
+<select name="<?php echo esc_attr( FPML_Settings::OPTION_KEY ); ?>[cron_frequency]">
+<option value="5min" <?php selected( $options['cron_frequency'], '5min' ); ?>><?php esc_html_e( 'Ogni 5 minuti', 'fp-multilanguage' ); ?></option>
+<option value="15min" <?php selected( $options['cron_frequency'], '15min' ); ?>><?php esc_html_e( 'Ogni 15 minuti', 'fp-multilanguage' ); ?></option>
+<option value="hourly" <?php selected( $options['cron_frequency'], 'hourly' ); ?>><?php esc_html_e( 'Ogni ora', 'fp-multilanguage' ); ?></option>
+</select>
+<p class="fpml-field-description"><?php esc_html_e( 'Imposta la frequenza degli eventi WP-Cron per la coda.', 'fp-multilanguage' ); ?></p>
+</td>
+</tr>
+<tr>
+<th scope="row"><?php esc_html_e( 'Tono marketing', 'fp-multilanguage' ); ?></th>
+<td>
+<label>
+<input type="checkbox" name="<?php echo esc_attr( FPML_Settings::OPTION_KEY ); ?>[marketing_tone]" value="1" <?php checked( $options['marketing_tone'], true ); ?> />
+<?php esc_html_e( 'Richiedi un tono leggermente promozionale nei testi.', 'fp-multilanguage' ); ?>
+</label>
+</td>
+</tr>
+<tr>
+<th scope="row"><?php esc_html_e( 'Preserva HTML', 'fp-multilanguage' ); ?></th>
+<td>
+<label>
+<input type="checkbox" name="<?php echo esc_attr( FPML_Settings::OPTION_KEY ); ?>[preserve_html]" value="1" <?php checked( $options['preserve_html'], true ); ?> />
+<?php esc_html_e( 'Mantieni tag HTML, shortcode e attributi senza tradurli.', 'fp-multilanguage' ); ?>
+</label>
+</td>
+</tr>
+<tr>
+<th scope="row"><?php esc_html_e( 'Traduci slug', 'fp-multilanguage' ); ?></th>
+<td>
+<label>
+<input type="checkbox" data-fpml-toggle-target="#fpml-slug-redirect" name="<?php echo esc_attr( FPML_Settings::OPTION_KEY ); ?>[translate_slugs]" value="1" <?php checked( $options['translate_slugs'], true ); ?> />
+<?php esc_html_e( 'Genera slug inglesi ottimizzati usando il provider.', 'fp-multilanguage' ); ?>
+</label>
+<p class="fpml-field-description"><?php esc_html_e( 'La traslitterazione base viene migliorata dal provider per mantenere semantica SEO.', 'fp-multilanguage' ); ?></p>
+</td>
+</tr>
+<tr id="fpml-slug-redirect" style="<?php echo $options['translate_slugs'] ? '' : 'display:none;'; ?>">
+<th scope="row"><?php esc_html_e( 'Redirect slug precedenti', 'fp-multilanguage' ); ?></th>
+<td>
+<label>
+<input type="checkbox" name="<?php echo esc_attr( FPML_Settings::OPTION_KEY ); ?>[slug_redirect]" value="1" <?php checked( $options['slug_redirect'], true ); ?> />
+<?php esc_html_e( 'Registra redirect 301 automatici quando cambia lo slug EN.', 'fp-multilanguage' ); ?>
+</label>
+</td>
+</tr>
+<tr>
+<th scope="row"><?php esc_html_e( 'Whitelist meta', 'fp-multilanguage' ); ?></th>
+<td>
+<textarea name="<?php echo esc_attr( FPML_Settings::OPTION_KEY ); ?>[meta_whitelist]" rows="3" cols="50" class="large-text code"><?php echo esc_textarea( $options['meta_whitelist'] ); ?></textarea>
+<p class="fpml-field-description"><?php esc_html_e( 'Meta key da copiare senza traduzione (separate da virgola).', 'fp-multilanguage' ); ?></p>
+</td>
+</tr>
+<tr>
+<th scope="row"><?php esc_html_e( 'Regex esclusione campi', 'fp-multilanguage' ); ?></th>
+<td>
+<textarea name="<?php echo esc_attr( FPML_Settings::OPTION_KEY ); ?>[exclude_regex]" rows="3" cols="50" class="large-text code"><?php echo esc_textarea( $options['exclude_regex'] ); ?></textarea>
+<p class="fpml-field-description"><?php esc_html_e( 'Pattern (uno per riga) per saltare campi o blocchi di contenuto.', 'fp-multilanguage' ); ?></p>
+</td>
+</tr>
+<tr>
+<th scope="row"><?php esc_html_e( 'Shortcode esclusi', 'fp-multilanguage' ); ?></th>
+<td>
+<textarea name="<?php echo esc_attr( FPML_Settings::OPTION_KEY ); ?>[excluded_shortcodes]" rows="3" cols="50" class="large-text code"><?php echo esc_textarea( $options['excluded_shortcodes'] ); ?></textarea>
+<p class="fpml-field-description"><?php esc_html_e( 'Inserisci slug shortcode da ignorare (uno per riga).', 'fp-multilanguage' ); ?></p>
+</td>
+</tr>
+</tbody>
+</table>
+<?php submit_button(); ?>
+</form>

--- a/fp-multilanguage/admin/views/settings-diagnostics.php
+++ b/fp-multilanguage/admin/views/settings-diagnostics.php
@@ -1,0 +1,284 @@
+<?php
+/**
+ * Diagnostics view.
+ *
+ * @package FP_Multilanguage
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+        exit;
+}
+
+$options = isset( $options ) ? $options : array();
+$plugin  = isset( $plugin ) && $plugin instanceof FPML_Plugin ? $plugin : FPML_Plugin::instance();
+
+$snapshot = isset( $diagnostics_snapshot ) && is_array( $diagnostics_snapshot ) ? $diagnostics_snapshot : $plugin->get_diagnostics_snapshot();
+
+$assisted_mode  = ! empty( $snapshot['assisted_mode'] );
+$assisted_reason = isset( $snapshot['assisted_reason'] ) ? $snapshot['assisted_reason'] : '';
+$assisted_message = isset( $snapshot['message'] ) ? $snapshot['message'] : '';
+
+if ( $assisted_mode ) {
+        $reason_map = array(
+                'wpml'      => 'WPML',
+                'polylang'  => 'Polylang',
+        );
+        $label      = isset( $reason_map[ $assisted_reason ] ) ? $reason_map[ $assisted_reason ] : '';
+        $suffix     = '' !== $label ? ' (' . $label . ')' : '';
+
+        echo '<div class="notice notice-info">';
+        echo '<p>' . esc_html( $assisted_message ? $assisted_message : __( 'Modalità assistita attiva: le metriche della coda interna non sono disponibili.', 'fp-multilanguage' ) ) . esc_html( $suffix ) . '</p>';
+        echo '</div>';
+
+        return;
+}
+
+$queue_counts    = isset( $snapshot['queue_counts'] ) && is_array( $snapshot['queue_counts'] ) ? $snapshot['queue_counts'] : array();
+$estimate        = isset( $snapshot['estimate'] ) && is_array( $snapshot['estimate'] ) ? $snapshot['estimate'] : array();
+$estimate_error  = isset( $snapshot['estimate_error'] ) ? $snapshot['estimate_error'] : '';
+$translator_data = isset( $snapshot['translator_status'] ) ? $snapshot['translator_status'] : array();
+$events          = isset( $snapshot['events'] ) && is_array( $snapshot['events'] ) ? $snapshot['events'] : array();
+$log_stats       = isset( $snapshot['log_stats'] ) && is_array( $snapshot['log_stats'] ) ? $snapshot['log_stats'] : array();
+$logs            = isset( $snapshot['logs'] ) && is_array( $snapshot['logs'] ) ? array_slice( $snapshot['logs'], 0, 10 ) : array();
+$recent_errors   = isset( $snapshot['recent_errors'] ) && is_array( $snapshot['recent_errors'] ) ? $snapshot['recent_errors'] : array();
+$batch_average   = isset( $snapshot['batch_average'] ) && is_array( $snapshot['batch_average'] ) ? $snapshot['batch_average'] : array();
+$lock_active     = ! empty( $snapshot['lock_active'] );
+$cron_disabled   = ! empty( $snapshot['cron_disabled'] );
+
+$pending_states = array( 'pending', 'translating', 'outdated' );
+$pending_jobs   = 0;
+foreach ( $pending_states as $pending_state ) {
+        $pending_jobs += isset( $queue_counts[ $pending_state ] ) ? (int) $queue_counts[ $pending_state ] : 0;
+}
+
+$done_jobs    = isset( $queue_counts['done'] ) ? (int) $queue_counts['done'] : 0;
+$skipped_jobs = isset( $queue_counts['skipped'] ) ? (int) $queue_counts['skipped'] : 0;
+$error_jobs   = isset( $queue_counts['error'] ) ? (int) $queue_counts['error'] : 0;
+
+$characters   = isset( $estimate['characters'] ) ? (int) $estimate['characters'] : 0;
+$words        = isset( $estimate['word_count'] ) ? (int) $estimate['word_count'] : 0;
+$cost         = isset( $estimate['estimated_cost'] ) ? (float) $estimate['estimated_cost'] : 0.0;
+$jobs_scanned = isset( $estimate['jobs_scanned'] ) ? (int) $estimate['jobs_scanned'] : 0;
+
+$average_duration = isset( $batch_average['duration'] ) ? (float) $batch_average['duration'] : 0.0;
+$average_jobs     = isset( $batch_average['jobs'] ) ? (float) $batch_average['jobs'] : 0.0;
+
+$provider_labels = array(
+        'openai'         => __( 'OpenAI', 'fp-multilanguage' ),
+        'deepl'          => __( 'DeepL', 'fp-multilanguage' ),
+        'google'         => __( 'Google Cloud Translation', 'fp-multilanguage' ),
+        'libretranslate' => __( 'LibreTranslate', 'fp-multilanguage' ),
+);
+
+$provider_slug  = isset( $translator_data['provider'] ) ? $translator_data['provider'] : '';
+$provider_name  = isset( $provider_labels[ $provider_slug ] ) ? $provider_labels[ $provider_slug ] : ( '' !== $provider_slug ? ucfirst( $provider_slug ) : __( 'Nessun provider', 'fp-multilanguage' ) );
+$provider_ready = ! empty( $translator_data['configured'] );
+$provider_error = isset( $translator_data['error'] ) ? $translator_data['error'] : '';
+
+$rest_nonce        = wp_create_nonce( 'wp_rest' );
+$run_endpoint      = esc_url( rest_url( 'fpml/v1/queue/run' ) );
+$test_endpoint     = esc_url( rest_url( 'fpml/v1/test-provider' ) );
+$reindex_endpoint  = esc_url( rest_url( 'fpml/v1/reindex' ) );
+?>
+
+<form method="post" action="<?php echo esc_url( admin_url( 'options.php' ) ); ?>">
+<?php settings_fields( 'fpml_settings_group' ); ?>
+<table class="form-table" role="presentation">
+        <tbody>
+                <tr>
+                        <th scope="row"><?php esc_html_e( 'Anonimizza log', 'fp-multilanguage' ); ?></th>
+                        <td>
+                                <label>
+                                        <input type="checkbox" name="<?php echo esc_attr( FPML_Settings::OPTION_KEY ); ?>[anonymize_logs]" value="1" <?php checked( $options['anonymize_logs'], true ); ?> />
+                                        <?php esc_html_e( 'Rimuovi dati personali dai log e dai report costi.', 'fp-multilanguage' ); ?>
+                                </label>
+                        </td>
+                </tr>
+        </tbody>
+</table>
+<p><?php esc_html_e( "Configura l'anonimizzazione e utilizza gli strumenti sottostanti per monitorare la pipeline.", 'fp-multilanguage' ); ?></p>
+<?php submit_button(); ?>
+</form>
+
+<div id="fpml-diagnostics-feedback" class="fpml-diagnostics-feedback" role="status" aria-live="polite"></div>
+
+<div class="fpml-diagnostics-grid">
+        <div class="fpml-diagnostics-card">
+                <h2><?php esc_html_e( 'Stato della coda', 'fp-multilanguage' ); ?></h2>
+                <table class="widefat striped fpml-diagnostics-table">
+                        <tbody>
+                                <tr>
+                                        <th scope="row"><?php esc_html_e( 'Da tradurre', 'fp-multilanguage' ); ?></th>
+                                        <td><?php echo esc_html( number_format_i18n( $pending_jobs ) ); ?></td>
+                                </tr>
+                                <tr>
+                                        <th scope="row"><?php esc_html_e( 'Tradotti', 'fp-multilanguage' ); ?></th>
+                                        <td><?php echo esc_html( number_format_i18n( $done_jobs ) ); ?></td>
+                                </tr>
+                                <tr>
+                                        <th scope="row"><?php esc_html_e( 'Saltati', 'fp-multilanguage' ); ?></th>
+                                        <td><?php echo esc_html( number_format_i18n( $skipped_jobs ) ); ?></td>
+                                </tr>
+                                <tr>
+                                        <th scope="row"><?php esc_html_e( 'Errori', 'fp-multilanguage' ); ?></th>
+                                        <td><?php echo esc_html( number_format_i18n( $error_jobs ) ); ?></td>
+                                </tr>
+                        </tbody>
+                </table>
+                <p>
+                        <?php
+                        printf(
+                                /* translators: 1: seconds, 2: jobs */
+                                esc_html__( 'Durata media batch: %1$.2fs — Job per batch: %2$.1f', 'fp-multilanguage' ),
+                                $average_duration,
+                                $average_jobs
+                        );
+                        ?>
+                </p>
+                <p class="fpml-diagnostics-actions">
+                        <button type="button" class="button button-secondary" data-fpml-action="run-queue" data-endpoint="<?php echo esc_url( $run_endpoint ); ?>" data-nonce="<?php echo esc_attr( $rest_nonce ); ?>" data-success-message="<?php echo esc_attr__( 'Batch eseguito. Aggiorna la pagina per aggiornare le metriche.', 'fp-multilanguage' ); ?>"><?php esc_html_e( 'Esegui batch ora', 'fp-multilanguage' ); ?></button>
+                        <button type="button" class="button" data-fpml-action="reindex" data-endpoint="<?php echo esc_url( $reindex_endpoint ); ?>" data-nonce="<?php echo esc_attr( $rest_nonce ); ?>" data-success-message="<?php echo esc_attr__( 'Reindex completato. Controlla la coda per nuovi job.', 'fp-multilanguage' ); ?>"><?php esc_html_e( 'Forza reindex', 'fp-multilanguage' ); ?></button>
+                </p>
+                <?php if ( $lock_active ) : ?>
+                        <p class="fpml-diagnostics-warning"><?php esc_html_e( 'Attenzione: il lock del processor è attivo. Attendi la fine del batch o usa WP-CLI per forzare il reset.', 'fp-multilanguage' ); ?></p>
+                <?php endif; ?>
+                <?php if ( $cron_disabled ) : ?>
+                        <p class="fpml-diagnostics-warning"><?php esc_html_e( 'WP-Cron è disabilitato: assicurati che il cron di sistema sia operativo.', 'fp-multilanguage' ); ?></p>
+                <?php endif; ?>
+        </div>
+
+        <div class="fpml-diagnostics-card">
+                <h2><?php esc_html_e( 'Stima costi e parole', 'fp-multilanguage' ); ?></h2>
+                <?php if ( $estimate_error ) : ?>
+                        <p class="fpml-diagnostics-warning"><?php echo esc_html( $estimate_error ); ?></p>
+                <?php endif; ?>
+                <table class="widefat striped fpml-diagnostics-table">
+                        <tbody>
+                                <tr>
+                                        <th scope="row"><?php esc_html_e( 'Caratteri in coda', 'fp-multilanguage' ); ?></th>
+                                        <td><?php echo esc_html( number_format_i18n( $characters ) ); ?></td>
+                                </tr>
+                                <tr>
+                                        <th scope="row"><?php esc_html_e( 'Parole da tradurre', 'fp-multilanguage' ); ?></th>
+                                        <td><?php echo esc_html( number_format_i18n( $words ) ); ?></td>
+                                </tr>
+                                <tr>
+                                        <th scope="row"><?php esc_html_e( 'Costo stimato', 'fp-multilanguage' ); ?></th>
+                                        <td><?php echo esc_html( number_format_i18n( $cost, 4 ) ); ?> €</td>
+                                </tr>
+                                <tr>
+                                        <th scope="row"><?php esc_html_e( 'Job analizzati', 'fp-multilanguage' ); ?></th>
+                                        <td><?php echo esc_html( number_format_i18n( $jobs_scanned ) ); ?></td>
+                                </tr>
+                        </tbody>
+                </table>
+                <p class="description"><?php esc_html_e( 'Il calcolo analizza un campione di job pendenti e utilizza la tariffa configurata per il provider attivo.', 'fp-multilanguage' ); ?></p>
+        </div>
+
+        <div class="fpml-diagnostics-card">
+                <h2><?php esc_html_e( 'Provider di traduzione', 'fp-multilanguage' ); ?></h2>
+                <p>
+                        <strong><?php esc_html_e( 'Provider attivo:', 'fp-multilanguage' ); ?></strong>
+                        <?php echo esc_html( $provider_name ); ?>
+                </p>
+                <?php if ( $provider_ready ) : ?>
+                        <p class="fpml-diagnostics-success"><?php esc_html_e( 'Configurazione valida. Esegui un test per verificarne la latenza.', 'fp-multilanguage' ); ?></p>
+                <?php else : ?>
+                        <p class="fpml-diagnostics-warning"><?php esc_html_e( 'Il provider selezionato non è pronto. Controlla chiavi API e impostazioni.', 'fp-multilanguage' ); ?></p>
+                        <?php if ( $provider_error ) : ?>
+                                <p class="fpml-diagnostics-warning"><?php echo esc_html( $provider_error ); ?></p>
+                        <?php endif; ?>
+                <?php endif; ?>
+                <p class="fpml-diagnostics-actions">
+                        <button type="button" class="button button-primary" data-fpml-action="test-provider" data-endpoint="<?php echo esc_url( $test_endpoint ); ?>" data-nonce="<?php echo esc_attr( $rest_nonce ); ?>" data-success-message="<?php echo esc_attr__( 'Test completato.', 'fp-multilanguage' ); ?>"><?php esc_html_e( 'Test provider', 'fp-multilanguage' ); ?></button>
+                </p>
+                <div class="fpml-provider-result" data-fpml-provider-result></div>
+        </div>
+
+        <div class="fpml-diagnostics-card">
+                <h2><?php esc_html_e( 'Eventi WP-Cron', 'fp-multilanguage' ); ?></h2>
+                <ul class="fpml-diagnostics-list">
+                        <?php foreach ( $events as $hook => $timestamp ) : ?>
+                                <li>
+                                        <strong><?php echo esc_html( $hook ); ?>:</strong>
+                                        <?php
+                                        if ( $timestamp ) {
+                                                echo esc_html( date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $timestamp ) );
+                                        } else {
+                                                esc_html_e( 'Non pianificato', 'fp-multilanguage' );
+                                        }
+                                        ?>
+                                </li>
+                        <?php endforeach; ?>
+                </ul>
+                <p class="description"><?php esc_html_e( 'Se gli eventi non risultano pianificati, verifica che il cron di sistema stia richiamando WordPress.', 'fp-multilanguage' ); ?></p>
+        </div>
+
+        <div class="fpml-diagnostics-card">
+                <h2><?php esc_html_e( 'Errori recenti', 'fp-multilanguage' ); ?></h2>
+                <?php if ( empty( $recent_errors ) ) : ?>
+                        <p><?php esc_html_e( 'Nessun errore registrato negli ultimi log.', 'fp-multilanguage' ); ?></p>
+                <?php else : ?>
+                        <ul class="fpml-diagnostics-list">
+                                <?php
+                                foreach ( $recent_errors as $error_entry ) {
+                                        $error_message = isset( $error_entry['message'] ) ? $error_entry['message'] : '';
+                                        $error_time    = isset( $error_entry['timestamp'] ) ? $error_entry['timestamp'] : '';
+                                        $formatted     = $error_time ? get_date_from_gmt( $error_time, get_option( 'date_format' ) . ' ' . get_option( 'time_format' ) ) : '';
+                                        ?>
+                                        <li>
+                                                <strong><?php echo esc_html( $formatted ); ?></strong>
+                                                <span><?php echo esc_html( $error_message ); ?></span>
+                                        </li>
+                                        <?php
+                                }
+                                ?>
+                        </ul>
+                <?php endif; ?>
+        </div>
+
+        <div class="fpml-diagnostics-card fpml-diagnostics-card--logs">
+                <h2><?php esc_html_e( 'Ultimi log', 'fp-multilanguage' ); ?></h2>
+                <p>
+                        <?php
+                        printf(
+                                /* translators: 1: info logs count, 2: warning logs count, 3: error logs count */
+                                esc_html__( 'Info: %1$d · Warning: %2$d · Errori: %3$d', 'fp-multilanguage' ),
+                                isset( $log_stats['info'] ) ? (int) $log_stats['info'] : 0,
+                                isset( $log_stats['warn'] ) ? (int) $log_stats['warn'] : 0,
+                                isset( $log_stats['error'] ) ? (int) $log_stats['error'] : 0
+                        );
+                        ?>
+                </p>
+                <?php if ( empty( $logs ) ) : ?>
+                        <p><?php esc_html_e( 'Nessun log disponibile.', 'fp-multilanguage' ); ?></p>
+                <?php else : ?>
+                        <table class="widefat striped fpml-diagnostics-table">
+                                <thead>
+                                        <tr>
+                                                <th scope="col"><?php esc_html_e( 'Data', 'fp-multilanguage' ); ?></th>
+                                                <th scope="col"><?php esc_html_e( 'Livello', 'fp-multilanguage' ); ?></th>
+                                                <th scope="col"><?php esc_html_e( 'Messaggio', 'fp-multilanguage' ); ?></th>
+                                        </tr>
+                                </thead>
+                                <tbody>
+                                        <?php
+                                        foreach ( $logs as $entry ) {
+                                                $timestamp = isset( $entry['timestamp'] ) ? $entry['timestamp'] : '';
+                                                $level     = isset( $entry['level'] ) ? $entry['level'] : 'info';
+                                                $message   = isset( $entry['message'] ) ? $entry['message'] : '';
+                                                $date      = $timestamp ? get_date_from_gmt( $timestamp, get_option( 'date_format' ) . ' ' . get_option( 'time_format' ) ) : '';
+                                                ?>
+                                                <tr>
+                                                        <td><?php echo esc_html( $date ); ?></td>
+                                                        <td><?php echo esc_html( ucfirst( $level ) ); ?></td>
+                                                        <td><?php echo esc_html( $message ); ?></td>
+                                                </tr>
+                                                <?php
+                                        }
+                                        ?>
+                                </tbody>
+                        </table>
+                <?php endif; ?>
+        </div>
+</div>

--- a/fp-multilanguage/admin/views/settings-export.php
+++ b/fp-multilanguage/admin/views/settings-export.php
@@ -1,0 +1,152 @@
+<?php
+/**
+ * Export & Import view.
+ *
+ * @package FP_Multilanguage
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+        exit;
+}
+
+$previews = isset( $exporter ) ? $exporter->get_sandbox_previews() : array();
+?>
+<div class="fpml-grid fpml-import-export">
+        <div>
+                <h2><?php esc_html_e( 'Stato traduzioni', 'fp-multilanguage' ); ?></h2>
+                <p><?php esc_html_e( 'Esporta o importa lo stato dei campi tradotti (post, tassonomie e menu) per sincronizzare ambienti diversi o ripristinare backup.', 'fp-multilanguage' ); ?></p>
+
+                <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="fpml-inline-form">
+                        <?php wp_nonce_field( 'fpml_export_state' ); ?>
+                        <input type="hidden" name="action" value="fpml_export_state" />
+                        <label>
+                                <span class="screen-reader-text"><?php esc_html_e( 'Formato export stato traduzioni', 'fp-multilanguage' ); ?></span>
+                                <select name="format">
+                                        <option value="json"><?php esc_html_e( 'JSON', 'fp-multilanguage' ); ?></option>
+                                        <option value="csv"><?php esc_html_e( 'CSV', 'fp-multilanguage' ); ?></option>
+                                </select>
+                        </label>
+                        <?php submit_button( __( 'Esporta stato', 'fp-multilanguage' ), 'secondary', 'submit', false ); ?>
+                </form>
+
+                <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="fpml-block-form">
+                        <?php wp_nonce_field( 'fpml_import_state' ); ?>
+                        <input type="hidden" name="action" value="fpml_import_state" />
+                        <p class="fpml-field-description"><?php esc_html_e( 'Incolla qui il contenuto JSON o CSV esportato in precedenza per riallineare gli stati di revisione.', 'fp-multilanguage' ); ?></p>
+                        <p>
+                                <label for="fpml-import-state-format"><?php esc_html_e( 'Formato sorgente', 'fp-multilanguage' ); ?></label>
+                                <select id="fpml-import-state-format" name="format">
+                                        <option value="json"><?php esc_html_e( 'JSON', 'fp-multilanguage' ); ?></option>
+                                        <option value="csv"><?php esc_html_e( 'CSV', 'fp-multilanguage' ); ?></option>
+                                </select>
+                        </p>
+                        <p>
+                                <label for="fpml-import-state-payload" class="screen-reader-text"><?php esc_html_e( 'Payload stato traduzioni', 'fp-multilanguage' ); ?></label>
+                                <textarea id="fpml-import-state-payload" name="payload" rows="6"></textarea>
+                        </p>
+                        <?php submit_button( __( 'Importa stato traduzioni', 'fp-multilanguage' ) ); ?>
+                </form>
+        </div>
+
+        <div>
+                <h2><?php esc_html_e( 'Log diagnostici', 'fp-multilanguage' ); ?></h2>
+                <p><?php esc_html_e( 'Scarica o carica i log per analisi offline: gli eventi importati vengono aggiunti mantenendo l’anonimizzazione se attiva.', 'fp-multilanguage' ); ?></p>
+
+                <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="fpml-inline-form">
+                        <?php wp_nonce_field( 'fpml_export_logs' ); ?>
+                        <input type="hidden" name="action" value="fpml_export_logs" />
+                        <label>
+                                <span class="screen-reader-text"><?php esc_html_e( 'Formato export log', 'fp-multilanguage' ); ?></span>
+                                <select name="format">
+                                        <option value="json"><?php esc_html_e( 'JSON', 'fp-multilanguage' ); ?></option>
+                                        <option value="csv"><?php esc_html_e( 'CSV', 'fp-multilanguage' ); ?></option>
+                                </select>
+                        </label>
+                        <?php submit_button( __( 'Esporta log', 'fp-multilanguage' ), 'secondary', 'submit', false ); ?>
+                </form>
+
+                <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="fpml-block-form">
+                        <?php wp_nonce_field( 'fpml_import_logs' ); ?>
+                        <input type="hidden" name="action" value="fpml_import_logs" />
+                        <p class="fpml-field-description"><?php esc_html_e( 'Incolla un export JSON o CSV per unire i log con l’istanza corrente (massimo 200 elementi).', 'fp-multilanguage' ); ?></p>
+                        <p>
+                                <label for="fpml-import-logs-format"><?php esc_html_e( 'Formato sorgente', 'fp-multilanguage' ); ?></label>
+                                <select id="fpml-import-logs-format" name="format">
+                                        <option value="json"><?php esc_html_e( 'JSON', 'fp-multilanguage' ); ?></option>
+                                        <option value="csv"><?php esc_html_e( 'CSV', 'fp-multilanguage' ); ?></option>
+                                </select>
+                        </p>
+                        <p>
+                                <label for="fpml-import-logs-payload" class="screen-reader-text"><?php esc_html_e( 'Payload log', 'fp-multilanguage' ); ?></label>
+                                <textarea id="fpml-import-logs-payload" name="payload" rows="6"></textarea>
+                        </p>
+                        <?php submit_button( __( 'Importa log', 'fp-multilanguage' ) ); ?>
+                </form>
+        </div>
+</div>
+
+<div class="fpml-sandbox-panel">
+        <h2><?php esc_html_e( 'Modalità sandbox', 'fp-multilanguage' ); ?></h2>
+        <p><?php esc_html_e( 'Quando la modalità sandbox è attiva, i job vengono processati senza salvare le modifiche: qui trovi l’anteprima delle ultime traduzioni simulate con caratteri, costo stimato e collegamenti utili.', 'fp-multilanguage' ); ?></p>
+
+        <?php if ( ! empty( $previews ) ) : ?>
+                <table class="widefat fixed fpml-table fpml-sandbox-table">
+                        <thead>
+                                <tr>
+                                        <th scope="col"><?php esc_html_e( 'Data', 'fp-multilanguage' ); ?></th>
+                                        <th scope="col"><?php esc_html_e( 'Oggetto', 'fp-multilanguage' ); ?></th>
+                                        <th scope="col"><?php esc_html_e( 'Campo', 'fp-multilanguage' ); ?></th>
+                                        <th scope="col"><?php esc_html_e( 'Provider', 'fp-multilanguage' ); ?></th>
+                                        <th scope="col"><?php esc_html_e( 'Caratteri / Parole', 'fp-multilanguage' ); ?></th>
+                                        <th scope="col"><?php esc_html_e( 'Costo stimato', 'fp-multilanguage' ); ?></th>
+                                        <th scope="col"><?php esc_html_e( 'Estratto sorgente', 'fp-multilanguage' ); ?></th>
+                                        <th scope="col"><?php esc_html_e( 'Estratto tradotto', 'fp-multilanguage' ); ?></th>
+                                </tr>
+                        </thead>
+                        <tbody>
+                                <?php foreach ( $previews as $preview ) : ?>
+                                        <tr>
+                                                <td><?php echo esc_html( mysql2date( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $preview['timestamp'] ) ); ?></td>
+                                                <td>
+                                                        <?php
+                                                        $object_label = sprintf( '#%d', isset( $preview['object_id'] ) ? absint( $preview['object_id'] ) : 0 );
+                                                        if ( ! empty( $preview['translation_url'] ) ) {
+                                                                printf( '<a href="%1$s" target="_blank" rel="noopener noreferrer">%2$s</a>', esc_url( $preview['translation_url'] ), esc_html( $object_label ) );
+                                                        } else {
+                                                                echo esc_html( $object_label );
+                                                        }
+                                                        ?>
+                                                </td>
+                                                <td><?php echo esc_html( isset( $preview['field'] ) ? $preview['field'] : '' ); ?></td>
+                                                <td><?php echo esc_html( isset( $preview['provider'] ) ? $preview['provider'] : '' ); ?></td>
+                                                <td>
+                                                        <?php
+                                                        $chars = isset( $preview['characters'] ) ? absint( $preview['characters'] ) : 0;
+                                                        $words = isset( $preview['word_count'] ) ? absint( $preview['word_count'] ) : 0;
+                                                        printf( '%1$s / %2$s', esc_html( number_format_i18n( $chars ) ), esc_html( number_format_i18n( $words ) ) );
+                                                        ?>
+                                                </td>
+                                                <td>
+                                                        <?php
+                                                        $cost = isset( $preview['estimated_cost'] ) ? (float) $preview['estimated_cost'] : 0.0;
+                                                        echo esc_html( wp_strip_all_tags( sprintf( '€ %s', number_format_i18n( $cost, 2 ) ) ) );
+                                                        ?>
+                                                </td>
+                                                <td><?php echo esc_html( isset( $preview['source_excerpt'] ) ? $preview['source_excerpt'] : '' ); ?></td>
+                                                <td><?php echo esc_html( isset( $preview['translated_excerpt'] ) ? $preview['translated_excerpt'] : '' ); ?></td>
+                                        </tr>
+                                <?php endforeach; ?>
+                        </tbody>
+                </table>
+
+                <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="fpml-inline-form">
+                        <?php wp_nonce_field( 'fpml_clear_sandbox' ); ?>
+                        <input type="hidden" name="action" value="fpml_clear_sandbox" />
+                        <?php submit_button( __( 'Svuota anteprime sandbox', 'fp-multilanguage' ), 'secondary', 'submit', false ); ?>
+                </form>
+        <?php else : ?>
+                <p><?php esc_html_e( 'Nessuna anteprima disponibile: attiva la modalità sandbox e avvia la coda per generare simulazioni.', 'fp-multilanguage' ); ?></p>
+        <?php endif; ?>
+
+        <p class="fpml-field-description"><?php esc_html_e( 'Esempi di file di export sono disponibili nella cartella docs/ del plugin.', 'fp-multilanguage' ); ?></p>
+</div>

--- a/fp-multilanguage/admin/views/settings-general.php
+++ b/fp-multilanguage/admin/views/settings-general.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * General settings view.
+ *
+ * @package FP_Multilanguage
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+exit;
+}
+
+$options = isset( $options ) ? $options : array();
+?>
+<form method="post" action="<?php echo esc_url( admin_url( 'options.php' ) ); ?>">
+<?php settings_fields( 'fpml_settings_group' ); ?>
+<table class="form-table" role="presentation">
+<tbody>
+<tr>
+<th scope="row"><?php esc_html_e( 'Provider predefinito', 'fp-multilanguage' ); ?></th>
+<td>
+<select name="<?php echo esc_attr( FPML_Settings::OPTION_KEY ); ?>[provider]">
+<option value="">&mdash; <?php esc_html_e( 'Seleziona', 'fp-multilanguage' ); ?> &mdash;</option>
+<option value="openai" <?php selected( $options['provider'], 'openai' ); ?>><?php esc_html_e( 'OpenAI', 'fp-multilanguage' ); ?></option>
+<option value="deepl" <?php selected( $options['provider'], 'deepl' ); ?>><?php esc_html_e( 'DeepL', 'fp-multilanguage' ); ?></option>
+<option value="google" <?php selected( $options['provider'], 'google' ); ?>><?php esc_html_e( 'Google Cloud Translation', 'fp-multilanguage' ); ?></option>
+<option value="libretranslate" <?php selected( $options['provider'], 'libretranslate' ); ?>><?php esc_html_e( 'LibreTranslate', 'fp-multilanguage' ); ?></option>
+</select>
+<p class="fpml-field-description"><?php esc_html_e( 'Seleziona il provider di traduzione principale. La traduzione viene bloccata se la chiave manca.', 'fp-multilanguage' ); ?></p>
+</td>
+</tr>
+<tr>
+<th scope="row"><?php esc_html_e( 'Chiave OpenAI', 'fp-multilanguage' ); ?></th>
+<td>
+<input type="password" class="regular-text" name="<?php echo esc_attr( FPML_Settings::OPTION_KEY ); ?>[openai_api_key]" value="<?php echo esc_attr( $options['openai_api_key'] ); ?>" autocomplete="off" />
+<p class="fpml-field-description"><?php esc_html_e( 'Richiesto per usare l\'API OpenAI (modello gpt-4o-mini o successivi).', 'fp-multilanguage' ); ?></p>
+</td>
+</tr>
+<tr>
+<th scope="row"><?php esc_html_e( 'Modello OpenAI', 'fp-multilanguage' ); ?></th>
+<td>
+<input type="text" class="regular-text" name="<?php echo esc_attr( FPML_Settings::OPTION_KEY ); ?>[openai_model]" value="<?php echo esc_attr( $options['openai_model'] ); ?>" />
+<p class="fpml-field-description"><?php esc_html_e( 'Modello consigliato: gpt-4o-mini. Assicurati che supporti input HTML.', 'fp-multilanguage' ); ?></p>
+</td>
+</tr>
+<tr>
+<th scope="row"><?php esc_html_e( 'Chiave DeepL', 'fp-multilanguage' ); ?></th>
+<td>
+<input type="password" class="regular-text" name="<?php echo esc_attr( FPML_Settings::OPTION_KEY ); ?>[deepl_api_key]" value="<?php echo esc_attr( $options['deepl_api_key'] ); ?>" autocomplete="off" />
+<label>
+<input type="checkbox" name="<?php echo esc_attr( FPML_Settings::OPTION_KEY ); ?>[deepl_use_free]" value="1" <?php checked( $options['deepl_use_free'], true ); ?> />
+<?php esc_html_e( 'Uso account DeepL Free', 'fp-multilanguage' ); ?>
+</label>
+</td>
+</tr>
+<tr>
+<th scope="row"><?php esc_html_e( 'Google Cloud Translation', 'fp-multilanguage' ); ?></th>
+<td>
+<input type="text" class="regular-text" name="<?php echo esc_attr( FPML_Settings::OPTION_KEY ); ?>[google_project_id]" value="<?php echo esc_attr( $options['google_project_id'] ); ?>" placeholder="<?php esc_attr_e( 'Project ID', 'fp-multilanguage' ); ?>" />
+<br />
+<input type="password" class="regular-text" name="<?php echo esc_attr( FPML_Settings::OPTION_KEY ); ?>[google_api_key]" value="<?php echo esc_attr( $options['google_api_key'] ); ?>" placeholder="<?php esc_attr_e( 'API Key', 'fp-multilanguage' ); ?>" autocomplete="off" />
+<p class="fpml-field-description"><?php esc_html_e( 'Supporto glossario se configurato nel progetto Google.', 'fp-multilanguage' ); ?></p>
+</td>
+</tr>
+<tr>
+<th scope="row"><?php esc_html_e( 'LibreTranslate', 'fp-multilanguage' ); ?></th>
+<td>
+<input type="url" class="regular-text" name="<?php echo esc_attr( FPML_Settings::OPTION_KEY ); ?>[libretranslate_api_url]" value="<?php echo esc_attr( $options['libretranslate_api_url'] ); ?>" placeholder="https://" />
+<br />
+<input type="password" class="regular-text" name="<?php echo esc_attr( FPML_Settings::OPTION_KEY ); ?>[libretranslate_api_key]" value="<?php echo esc_attr( $options['libretranslate_api_key'] ); ?>" autocomplete="off" />
+<p class="fpml-field-description"><?php esc_html_e( 'Inserisci endpoint self-hosted per garantire performance e privacy.', 'fp-multilanguage' ); ?></p>
+</td>
+</tr>
+<tr>
+<th scope="row"><?php esc_html_e( 'Routing lingua', 'fp-multilanguage' ); ?></th>
+<td>
+<label>
+<input type="radio" name="<?php echo esc_attr( FPML_Settings::OPTION_KEY ); ?>[routing_mode]" value="segment" <?php checked( $options['routing_mode'], 'segment' ); ?> />
+<?php esc_html_e( 'Segmento /en/', 'fp-multilanguage' ); ?>
+</label>
+<br />
+<label>
+<input type="radio" name="<?php echo esc_attr( FPML_Settings::OPTION_KEY ); ?>[routing_mode]" value="query" <?php checked( $options['routing_mode'], 'query' ); ?> />
+<?php esc_html_e( 'Query string ?lang=en', 'fp-multilanguage' ); ?>
+</label>
+<p class="fpml-field-description"><?php esc_html_e( 'Scegli il meccanismo preferito per la lingua inglese.', 'fp-multilanguage' ); ?></p>
+</td>
+</tr>
+<tr>
+<th scope="row"><?php esc_html_e( 'Redirect lingua browser', 'fp-multilanguage' ); ?></th>
+<td>
+<label>
+<input type="checkbox" name="<?php echo esc_attr( FPML_Settings::OPTION_KEY ); ?>[browser_redirect]" value="1" <?php checked( $options['browser_redirect'], true ); ?> />
+<?php esc_html_e( 'Reindirizza automaticamente alla lingua inglese alla prima visita se il browser la preferisce.', 'fp-multilanguage' ); ?>
+</label>
+<p class="fpml-field-description"><?php esc_html_e( 'Il redirect rispetta il consenso cookie quando configurato.', 'fp-multilanguage' ); ?></p>
+</td>
+</tr>
+<tr>
+<th scope="row"><?php esc_html_e( 'Consenso cookie per redirect', 'fp-multilanguage' ); ?></th>
+<td>
+<label>
+<input type="checkbox" name="<?php echo esc_attr( FPML_Settings::OPTION_KEY ); ?>[browser_redirect_requires_consent]" value="1" <?php checked( $options['browser_redirect_requires_consent'], true ); ?> />
+<?php esc_html_e( 'Attiva il redirect solo se il consenso cookie è stato espresso.', 'fp-multilanguage' ); ?>
+</label>
+<p class="fpml-field-description"><?php esc_html_e( 'Specifica il nome del cookie (es. cookieyes-consent) che indica il consenso. Se vuoto o assente, il redirect non avviene e non viene salvata alcuna preferenza.', 'fp-multilanguage' ); ?></p>
+<input type="text" class="regular-text" name="<?php echo esc_attr( FPML_Settings::OPTION_KEY ); ?>[browser_redirect_consent_cookie]" value="<?php echo esc_attr( $options['browser_redirect_consent_cookie'] ); ?>" placeholder="<?php esc_attr_e( 'Nome cookie consenso', 'fp-multilanguage' ); ?>" />
+</td>
+</tr>
+<tr>
+<th scope="row"><?php esc_html_e( 'Modalità sandbox', 'fp-multilanguage' ); ?></th>
+<td>
+<label>
+<input type="checkbox" name="<?php echo esc_attr( FPML_Settings::OPTION_KEY ); ?>[sandbox_mode]" value="1" <?php checked( $options['sandbox_mode'], true ); ?> />
+<?php esc_html_e( 'Esegui la pipeline senza salvare i risultati. Mostra anteprima diff e costi stimati.', 'fp-multilanguage' ); ?>
+</label>
+</td>
+</tr>
+<tr>
+<th scope="row"><?php esc_html_e( 'Elimina dati alla disinstallazione', 'fp-multilanguage' ); ?></th>
+<td>
+<label>
+<input type="checkbox" name="<?php echo esc_attr( FPML_Settings::OPTION_KEY ); ?>[remove_data]" value="1" <?php checked( $options['remove_data'], true ); ?> />
+<?php esc_html_e( 'Cancella tabelle, opzioni e log quando il plugin viene rimosso.', 'fp-multilanguage' ); ?>
+</label>
+</td>
+</tr>
+</tbody>
+</table>
+<?php submit_button(); ?>
+</form>

--- a/fp-multilanguage/admin/views/settings-glossary.php
+++ b/fp-multilanguage/admin/views/settings-glossary.php
@@ -1,0 +1,133 @@
+<?php
+/**
+ * Glossary settings view.
+ *
+ * @package FP_Multilanguage
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+$options  = isset( $options ) ? $options : array();
+$glossary = isset( $glossary ) ? $glossary : FPML_Glossary::instance();
+$entries  = $glossary->get_entries();
+?>
+
+<form method="post" action="<?php echo esc_url( admin_url( 'options.php' ) ); ?>">
+    <?php settings_fields( 'fpml_settings_group' ); ?>
+    <table class="form-table" role="presentation">
+        <tbody>
+        <tr>
+            <th scope="row"><?php esc_html_e( 'Case sensitive', 'fp-multilanguage' ); ?></th>
+            <td>
+                <label>
+                    <input type="checkbox" name="<?php echo esc_attr( FPML_Settings::OPTION_KEY ); ?>[glossary_case_sensitive]" value="1" <?php checked( $options['glossary_case_sensitive'], true ); ?> />
+                    <?php esc_html_e( 'Applica le voci del glossario rispettando maiuscole/minuscole.', 'fp-multilanguage' ); ?>
+                </label>
+            </td>
+        </tr>
+        </tbody>
+    </table>
+    <?php submit_button( esc_html__( 'Salva impostazioni', 'fp-multilanguage' ) ); ?>
+</form>
+
+<hr />
+
+<h2><?php esc_html_e( 'Voci glossario', 'fp-multilanguage' ); ?></h2>
+<p><?php esc_html_e( 'Il glossario ha priorità assoluta sulle traduzioni automatiche: i termini italiani verranno sostituiti con le forme inglesi indicate prima e dopo la chiamata al provider.', 'fp-multilanguage' ); ?></p>
+
+<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="fpml-block-form">
+    <?php wp_nonce_field( 'fpml_save_glossary' ); ?>
+    <input type="hidden" name="action" value="fpml_save_glossary" />
+    <table class="widefat fpml-table">
+        <thead>
+        <tr>
+            <th scope="col"><?php esc_html_e( 'Termine IT', 'fp-multilanguage' ); ?></th>
+            <th scope="col"><?php esc_html_e( 'Traduzione EN', 'fp-multilanguage' ); ?></th>
+            <th scope="col"><?php esc_html_e( 'Contesto', 'fp-multilanguage' ); ?></th>
+            <th scope="col"><?php esc_html_e( 'Azioni', 'fp-multilanguage' ); ?></th>
+        </tr>
+        </thead>
+        <tbody>
+        <?php if ( empty( $entries ) ) : ?>
+            <tr>
+                <td colspan="4"><?php esc_html_e( 'Nessuna voce salvata.', 'fp-multilanguage' ); ?></td>
+            </tr>
+        <?php else : ?>
+            <?php foreach ( $entries as $key => $row ) : ?>
+                <tr>
+                    <td>
+                        <input type="text" class="regular-text" name="entries[<?php echo esc_attr( $key ); ?>][source]" value="<?php echo esc_attr( $row['source'] ); ?>" />
+                    </td>
+                    <td>
+                        <input type="text" class="regular-text" name="entries[<?php echo esc_attr( $key ); ?>][target]" value="<?php echo esc_attr( $row['target'] ); ?>" />
+                    </td>
+                    <td>
+                        <input type="text" class="regular-text" name="entries[<?php echo esc_attr( $key ); ?>][context]" value="<?php echo esc_attr( isset( $row['context'] ) ? $row['context'] : '' ); ?>" />
+                    </td>
+                    <td>
+                        <label>
+                            <input type="checkbox" name="entries[<?php echo esc_attr( $key ); ?>][delete]" value="1" />
+                            <?php esc_html_e( 'Elimina', 'fp-multilanguage' ); ?>
+                        </label>
+                    </td>
+                </tr>
+            <?php endforeach; ?>
+        <?php endif; ?>
+        </tbody>
+    </table>
+
+    <h3><?php esc_html_e( 'Aggiungi nuova voce', 'fp-multilanguage' ); ?></h3>
+    <div class="fpml-flex-group">
+        <p>
+            <label for="fpml_new_glossary_source"><?php esc_html_e( 'Termine italiano', 'fp-multilanguage' ); ?></label><br />
+            <input type="text" class="regular-text" id="fpml_new_glossary_source" name="new_glossary_source" />
+        </p>
+        <p>
+            <label for="fpml_new_glossary_target"><?php esc_html_e( 'Traduzione inglese', 'fp-multilanguage' ); ?></label><br />
+            <input type="text" class="regular-text" id="fpml_new_glossary_target" name="new_glossary_target" />
+        </p>
+        <p>
+            <label for="fpml_new_glossary_context"><?php esc_html_e( 'Contesto (facoltativo)', 'fp-multilanguage' ); ?></label><br />
+            <input type="text" class="regular-text" id="fpml_new_glossary_context" name="new_glossary_context" />
+        </p>
+    </div>
+
+    <?php submit_button( esc_html__( 'Salva glossario', 'fp-multilanguage' ) ); ?>
+</form>
+
+<div class="fpml-grid fpml-import-export">
+    <div>
+        <h3><?php esc_html_e( 'Importa glossario', 'fp-multilanguage' ); ?></h3>
+        <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+            <?php wp_nonce_field( 'fpml_import_glossary' ); ?>
+            <input type="hidden" name="action" value="fpml_import_glossary" />
+            <p>
+                <label for="fpml_import_glossary_payload" class="screen-reader-text"><?php esc_html_e( 'Payload glossario', 'fp-multilanguage' ); ?></label>
+                <textarea id="fpml_import_glossary_payload" name="payload" rows="6" class="large-text" placeholder="<?php esc_attr_e( 'Incolla JSON o CSV (header: source,target,context)', 'fp-multilanguage' ); ?>"></textarea>
+            </p>
+            <p>
+                <label><input type="radio" name="format" value="json" checked /> <?php esc_html_e( 'JSON', 'fp-multilanguage' ); ?></label>
+                <label><input type="radio" name="format" value="csv" /> <?php esc_html_e( 'CSV', 'fp-multilanguage' ); ?></label>
+            </p>
+            <?php submit_button( esc_html__( 'Importa', 'fp-multilanguage' ), 'secondary' ); ?>
+        </form>
+    </div>
+    <div>
+        <h3><?php esc_html_e( 'Export glossario', 'fp-multilanguage' ); ?></h3>
+        <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+            <?php wp_nonce_field( 'fpml_export_glossary' ); ?>
+            <input type="hidden" name="action" value="fpml_export_glossary" />
+            <p>
+                <select name="format">
+                    <option value="json"><?php esc_html_e( 'JSON', 'fp-multilanguage' ); ?></option>
+                    <option value="csv"><?php esc_html_e( 'CSV', 'fp-multilanguage' ); ?></option>
+                </select>
+            </p>
+            <?php submit_button( esc_html__( 'Scarica', 'fp-multilanguage' ), 'secondary' ); ?>
+        </form>
+    </div>
+</div>
+
+<p class="description"><?php esc_html_e( 'Suggerimento: ordina le voci per lunghezza (termini più lunghi prima) per evitare sovrapposizioni indesiderate.', 'fp-multilanguage' ); ?></p>

--- a/fp-multilanguage/admin/views/settings-seo.php
+++ b/fp-multilanguage/admin/views/settings-seo.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * SEO settings view.
+ *
+ * @package FP_Multilanguage
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+exit;
+}
+
+$options = isset( $options ) ? $options : array();
+?>
+<form method="post" action="<?php echo esc_url( admin_url( 'options.php' ) ); ?>">
+<?php settings_fields( 'fpml_settings_group' ); ?>
+<table class="form-table" role="presentation">
+<tbody>
+<tr>
+<th scope="row"><?php esc_html_e( 'Noindex lingua EN', 'fp-multilanguage' ); ?></th>
+<td>
+<label>
+<input type="checkbox" name="<?php echo esc_attr( FPML_Settings::OPTION_KEY ); ?>[noindex_en]" value="1" <?php checked( $options['noindex_en'], true ); ?> />
+<?php esc_html_e( 'Applica meta robots noindex,nofollow alle versioni inglesi.', 'fp-multilanguage' ); ?>
+</label>
+</td>
+</tr>
+<tr>
+<th scope="row"><?php esc_html_e( 'Sitemap EN', 'fp-multilanguage' ); ?></th>
+<td>
+<label>
+<input type="checkbox" name="<?php echo esc_attr( FPML_Settings::OPTION_KEY ); ?>[sitemap_en]" value="1" <?php checked( $options['sitemap_en'], true ); ?> />
+<?php esc_html_e( 'Pubblica sitemap inglese e integra con plugin SEO presenti.', 'fp-multilanguage' ); ?>
+</label>
+</td>
+</tr>
+<tr>
+<th scope="row"><?php esc_html_e( 'Tariffe provider (€/K caratteri)', 'fp-multilanguage' ); ?></th>
+<td>
+<div class="fpml-rate-grid">
+<label>
+<span><?php esc_html_e( 'OpenAI', 'fp-multilanguage' ); ?></span><br />
+<input type="text" class="small-text" name="<?php echo esc_attr( FPML_Settings::OPTION_KEY ); ?>[rate_openai]" value="<?php echo esc_attr( $options['rate_openai'] ); ?>" />
+</label>
+<label>
+<span><?php esc_html_e( 'DeepL', 'fp-multilanguage' ); ?></span><br />
+<input type="text" class="small-text" name="<?php echo esc_attr( FPML_Settings::OPTION_KEY ); ?>[rate_deepl]" value="<?php echo esc_attr( $options['rate_deepl'] ); ?>" />
+</label>
+<label>
+<span><?php esc_html_e( 'Google', 'fp-multilanguage' ); ?></span><br />
+<input type="text" class="small-text" name="<?php echo esc_attr( FPML_Settings::OPTION_KEY ); ?>[rate_google]" value="<?php echo esc_attr( $options['rate_google'] ); ?>" />
+</label>
+<label>
+<span><?php esc_html_e( 'LibreTranslate', 'fp-multilanguage' ); ?></span><br />
+<input type="text" class="small-text" name="<?php echo esc_attr( FPML_Settings::OPTION_KEY ); ?>[rate_libretranslate]" value="<?php echo esc_attr( $options['rate_libretranslate'] ); ?>" />
+</label>
+</div>
+<p class="fpml-field-description"><?php esc_html_e( 'Utilizzato per stimare i costi nelle dashboard e nei report.', 'fp-multilanguage' ); ?></p>
+</td>
+</tr>
+</tbody>
+</table>
+<?php submit_button(); ?>
+</form>

--- a/fp-multilanguage/admin/views/settings-strings.php
+++ b/fp-multilanguage/admin/views/settings-strings.php
@@ -1,0 +1,192 @@
+<?php
+/**
+ * Strings settings view.
+ *
+ * @package FP_Multilanguage
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+$options          = isset( $options ) ? $options : array();
+$scanner          = isset( $scanner ) ? $scanner : FPML_Strings_Scanner::instance();
+$overrides_object = isset( $overrides ) ? $overrides : FPML_Strings_Override::instance();
+$catalog          = $scanner->get_catalog();
+$total_strings    = count( $catalog );
+$catalog_preview  = array_slice( $catalog, 0, 100, true );
+$last_scan        = $scanner->get_last_scan_time();
+$last_scan_label  = $last_scan ? date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $last_scan ) : esc_html__( 'Mai eseguita', 'fp-multilanguage' );
+$overrides_list   = $overrides_object->get_overrides();
+?>
+
+<h2><?php esc_html_e( 'Scanner stringhe', 'fp-multilanguage' ); ?></h2>
+<p>
+    <?php
+    printf(
+        /* translators: 1: total strings, 2: last scan timestamp */
+        esc_html__( 'Stringhe rilevate: %1$d. Ultima scansione: %2$s.', 'fp-multilanguage' ),
+        absint( $total_strings ),
+        esc_html( $last_scan_label )
+    );
+    ?>
+</p>
+<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="fpml-inline-form">
+    <?php wp_nonce_field( 'fpml_scan_strings' ); ?>
+    <input type="hidden" name="action" value="fpml_scan_strings" />
+    <?php submit_button( esc_html__( 'Scansiona stringhe attive', 'fp-multilanguage' ), 'secondary', 'submit', false ); ?>
+</form>
+
+<?php if ( ! empty( $catalog_preview ) ) : ?>
+    <table class="widefat striped fpml-table">
+        <thead>
+        <tr>
+            <th scope="col"><?php esc_html_e( 'Testo originale', 'fp-multilanguage' ); ?></th>
+            <th scope="col"><?php esc_html_e( 'Dominio', 'fp-multilanguage' ); ?></th>
+            <th scope="col"><?php esc_html_e( 'Contesto', 'fp-multilanguage' ); ?></th>
+            <th scope="col"><?php esc_html_e( 'Occorrenze', 'fp-multilanguage' ); ?></th>
+            <th scope="col"><?php esc_html_e( 'File', 'fp-multilanguage' ); ?></th>
+        </tr>
+        </thead>
+        <tbody>
+        <?php foreach ( $catalog_preview as $entry ) : ?>
+            <tr>
+                <td><code><?php echo esc_html( $entry['original'] ); ?></code></td>
+                <td><?php echo '' !== $entry['domain'] ? esc_html( $entry['domain'] ) : '&mdash;'; ?></td>
+                <td><?php echo '' !== $entry['context'] ? esc_html( $entry['context'] ) : '&mdash;'; ?></td>
+                <td><?php echo esc_html( (string) $entry['occurrences'] ); ?></td>
+                <td>
+                    <?php
+                    $locations = array();
+                    foreach ( $entry['files'] as $file ) {
+                        $file_path = isset( $file['file'] ) ? $file['file'] : '';
+                        $line      = isset( $file['line'] ) ? (int) $file['line'] : 0;
+                        $locations[] = $file_path ? $file_path . ( $line ? ':' . $line : '' ) : '';
+                    }
+                    $locations = array_filter( array_unique( $locations ) );
+
+                    if ( empty( $locations ) ) {
+                        echo '&mdash;';
+                    } else {
+                        echo esc_html( implode( ', ', $locations ) );
+                    }
+                    ?>
+                </td>
+            </tr>
+        <?php endforeach; ?>
+        </tbody>
+    </table>
+    <?php if ( $total_strings > count( $catalog_preview ) ) : ?>
+        <p class="description">
+            <?php
+            printf(
+                /* translators: %d: number of rows displayed */
+                esc_html__( 'Mostrate le prime %d stringhe. Esegui una scansione completa per aggiornare il catalogo.', 'fp-multilanguage' ),
+                count( $catalog_preview )
+            );
+            ?>
+        </p>
+    <?php endif; ?>
+<?php else : ?>
+    <p class="description"><?php esc_html_e( 'Nessuna stringa catalogata al momento. Avvia una scansione per popolare il catalogo.', 'fp-multilanguage' ); ?></p>
+<?php endif; ?>
+
+<hr />
+
+<h2><?php esc_html_e( 'Override manuali', 'fp-multilanguage' ); ?></h2>
+<p><?php esc_html_e( 'Definisci traduzioni manuali per stringhe specifiche usate nei temi o nei plugin attivi. Le traduzioni saranno applicate solo alla lingua inglese.', 'fp-multilanguage' ); ?></p>
+
+<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="fpml-block-form">
+    <?php wp_nonce_field( 'fpml_save_overrides' ); ?>
+    <input type="hidden" name="action" value="fpml_save_overrides" />
+    <table class="widefat fpml-table">
+        <thead>
+        <tr>
+            <th scope="col"><?php esc_html_e( 'Originale (IT)', 'fp-multilanguage' ); ?></th>
+            <th scope="col"><?php esc_html_e( 'Traduzione EN', 'fp-multilanguage' ); ?></th>
+            <th scope="col"><?php esc_html_e( 'Contesto', 'fp-multilanguage' ); ?></th>
+            <th scope="col"><?php esc_html_e( 'Azioni', 'fp-multilanguage' ); ?></th>
+        </tr>
+        </thead>
+        <tbody>
+        <?php if ( empty( $overrides_list ) ) : ?>
+            <tr>
+                <td colspan="4"><?php esc_html_e( 'Nessuna override presente.', 'fp-multilanguage' ); ?></td>
+            </tr>
+        <?php else : ?>
+            <?php foreach ( $overrides_list as $hash => $row ) : ?>
+                <tr>
+                    <td>
+                        <code><?php echo esc_html( $row['source'] ); ?></code>
+                    </td>
+                    <td>
+                        <label for="fpml_override_<?php echo esc_attr( $hash ); ?>" class="screen-reader-text"><?php esc_html_e( 'Traduzione EN', 'fp-multilanguage' ); ?></label>
+                        <input type="text" class="regular-text" id="fpml_override_<?php echo esc_attr( $hash ); ?>" name="overrides[<?php echo esc_attr( $hash ); ?>][target]" value="<?php echo esc_attr( $row['target'] ); ?>" />
+                    </td>
+                    <td>
+                        <label for="fpml_override_context_<?php echo esc_attr( $hash ); ?>" class="screen-reader-text"><?php esc_html_e( 'Contesto', 'fp-multilanguage' ); ?></label>
+                        <input type="text" class="regular-text" id="fpml_override_context_<?php echo esc_attr( $hash ); ?>" name="overrides[<?php echo esc_attr( $hash ); ?>][context]" value="<?php echo esc_attr( isset( $row['context'] ) ? $row['context'] : '' ); ?>" />
+                    </td>
+                    <td>
+                        <label>
+                            <input type="checkbox" name="overrides[<?php echo esc_attr( $hash ); ?>][delete]" value="1" />
+                            <?php esc_html_e( 'Elimina', 'fp-multilanguage' ); ?>
+                        </label>
+                    </td>
+                </tr>
+            <?php endforeach; ?>
+        <?php endif; ?>
+        </tbody>
+    </table>
+
+    <h3><?php esc_html_e( 'Aggiungi nuova override', 'fp-multilanguage' ); ?></h3>
+    <div class="fpml-flex-group">
+        <p>
+            <label for="fpml_new_override_source"><?php esc_html_e( 'Stringa originale (IT)', 'fp-multilanguage' ); ?></label><br />
+            <input type="text" class="regular-text" id="fpml_new_override_source" name="new_source" />
+        </p>
+        <p>
+            <label for="fpml_new_override_target"><?php esc_html_e( 'Traduzione EN', 'fp-multilanguage' ); ?></label><br />
+            <input type="text" class="regular-text" id="fpml_new_override_target" name="new_target" />
+        </p>
+        <p>
+            <label for="fpml_new_override_context"><?php esc_html_e( 'Contesto (facoltativo)', 'fp-multilanguage' ); ?></label><br />
+            <input type="text" class="regular-text" id="fpml_new_override_context" name="new_context" />
+        </p>
+    </div>
+
+    <?php submit_button( esc_html__( 'Salva override', 'fp-multilanguage' ) ); ?>
+</form>
+
+<div class="fpml-grid fpml-import-export">
+    <div>
+        <h3><?php esc_html_e( 'Importa override', 'fp-multilanguage' ); ?></h3>
+        <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+            <?php wp_nonce_field( 'fpml_import_overrides' ); ?>
+            <input type="hidden" name="action" value="fpml_import_overrides" />
+            <p>
+                <label for="fpml_import_overrides_payload" class="screen-reader-text"><?php esc_html_e( 'Payload override', 'fp-multilanguage' ); ?></label>
+                <textarea id="fpml_import_overrides_payload" name="payload" rows="6" class="large-text" placeholder="<?php esc_attr_e( 'Incolla JSON o CSV (header: source,target,context)', 'fp-multilanguage' ); ?>"></textarea>
+            </p>
+            <p>
+                <label><input type="radio" name="format" value="json" checked /> <?php esc_html_e( 'JSON', 'fp-multilanguage' ); ?></label>
+                <label><input type="radio" name="format" value="csv" /> <?php esc_html_e( 'CSV', 'fp-multilanguage' ); ?></label>
+            </p>
+            <?php submit_button( esc_html__( 'Importa', 'fp-multilanguage' ), 'secondary' ); ?>
+        </form>
+    </div>
+    <div>
+        <h3><?php esc_html_e( 'Export override', 'fp-multilanguage' ); ?></h3>
+        <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+            <?php wp_nonce_field( 'fpml_export_overrides' ); ?>
+            <input type="hidden" name="action" value="fpml_export_overrides" />
+            <p>
+                <select name="format">
+                    <option value="json"><?php esc_html_e( 'JSON', 'fp-multilanguage' ); ?></option>
+                    <option value="csv"><?php esc_html_e( 'CSV', 'fp-multilanguage' ); ?></option>
+                </select>
+            </p>
+            <?php submit_button( esc_html__( 'Scarica', 'fp-multilanguage' ), 'secondary' ); ?>
+        </form>
+    </div>
+</div>

--- a/fp-multilanguage/assets/admin.css
+++ b/fp-multilanguage/assets/admin.css
@@ -1,0 +1,216 @@
+/*
+ * Admin styles for FP Multilanguage.
+ * @since 0.2.0
+ */
+
+.fpml-settings-wrap {
+background: #fff;
+padding: 20px;
+border: 1px solid #dcdcde;
+border-radius: 4px;
+}
+
+.fpml-settings-tabs {
+display: flex;
+gap: 8px;
+margin-bottom: 20px;
+}
+
+.fpml-settings-tabs a.nav-tab-active {
+background-color: #007cba;
+color: #fff;
+}
+
+.fpml-field-description {
+color: #50575e;
+font-size: 13px;
+}
+
+.fpml-rate-grid {
+display: flex;
+flex-wrap: wrap;
+gap: 12px;
+}
+
+.fpml-rate-grid label {
+display: flex;
+flex-direction: column;
+gap: 4px;
+}
+
+.fpml-inline-form {
+margin: 0 0 16px;
+display: inline-block;
+}
+
+.fpml-block-form {
+margin-top: 20px;
+}
+
+.fpml-table th,
+.fpml-table td {
+vertical-align: top;
+}
+
+.fpml-flex-group {
+display: flex;
+flex-wrap: wrap;
+gap: 16px;
+margin-top: 12px;
+}
+
+.fpml-flex-group p {
+flex: 1 1 220px;
+margin: 0;
+}
+
+.fpml-grid {
+display: flex;
+flex-wrap: wrap;
+gap: 24px;
+margin-top: 24px;
+}
+
+.fpml-grid > div {
+flex: 1 1 280px;
+}
+
+.fpml-import-export textarea {
+width: 100%;
+}
+
+.fpml-import-export select {
+min-width: 120px;
+}
+
+.fpml-sandbox-panel {
+margin-top: 32px;
+padding: 20px;
+border: 1px solid #dcdcde;
+border-radius: 4px;
+background: #fff;
+}
+
+.fpml-sandbox-table td,
+.fpml-sandbox-table th {
+word-break: break-word;
+}
+
+.fpml-diagnostics-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 20px;
+    margin-top: 24px;
+}
+
+.fpml-diagnostics-card {
+    background: #fff;
+    border: 1px solid #dcdcde;
+    border-radius: 4px;
+    padding: 20px;
+}
+
+.fpml-diagnostics-card h2 {
+    margin-top: 0;
+    font-size: 18px;
+}
+
+.fpml-diagnostics-table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.fpml-diagnostics-table th,
+.fpml-diagnostics-table td {
+    padding: 6px 0;
+    border-bottom: 1px solid #f0f0f1;
+}
+
+.fpml-diagnostics-feedback {
+    margin-top: 16px;
+    padding: 10px 14px;
+    border-radius: 4px;
+    border: 1px solid transparent;
+    background: #f6f7f7;
+    color: #1d2327;
+}
+
+.fpml-diagnostics-feedback.is-success {
+    border-color: #46b450;
+    background: #ecf7ed;
+}
+
+.fpml-diagnostics-feedback.is-error {
+    border-color: #d63638;
+    background: #fce8e6;
+    color: #d63638;
+}
+
+.fpml-diagnostics-feedback.is-info {
+    border-color: #2271b1;
+    background: #f0f6fc;
+}
+
+.fpml-diagnostics-warning {
+    color: #d63638;
+    font-weight: 600;
+}
+
+.fpml-diagnostics-success {
+    color: #198754;
+    font-weight: 600;
+}
+
+.fpml-diagnostics-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-top: 12px;
+}
+
+.fpml-diagnostics-list {
+    margin: 0;
+    padding-left: 18px;
+}
+
+.fpml-diagnostics-list li {
+    margin-bottom: 6px;
+}
+
+.fpml-provider-result {
+    margin-top: 12px;
+}
+
+.fpml-provider-result__metrics {
+    display: grid;
+    grid-template-columns: max-content 1fr;
+    gap: 6px 12px;
+    margin: 0 0 12px;
+}
+
+.fpml-provider-result__metrics dt {
+    font-weight: 600;
+}
+
+.fpml-provider-result__metrics dd {
+    margin: 0;
+}
+
+.fpml-provider-result__title {
+    margin: 12px 0 4px;
+    font-size: 14px;
+    font-weight: 600;
+}
+
+.fpml-provider-result__text {
+    margin: 0;
+    padding: 10px;
+    background: #f6f7f7;
+    border: 1px solid #dcdcde;
+    border-radius: 4px;
+    white-space: pre-wrap;
+}
+
+.fpml-diagnostics-card--logs table {
+    margin-top: 12px;
+}

--- a/fp-multilanguage/assets/admin.js
+++ b/fp-multilanguage/assets/admin.js
@@ -1,0 +1,165 @@
+/*
+ * Admin scripts for FP Multilanguage.
+ * @since 0.2.0
+ */
+(function () {
+    const toggles = document.querySelectorAll('[data-fpml-toggle-target]');
+    toggles.forEach((toggle) => {
+        const trigger = () => {
+            const targetSelector = toggle.getAttribute('data-fpml-toggle-target');
+            if (!targetSelector) {
+                return;
+            }
+
+            targetSelector.split(',').forEach((selector) => {
+                const element = document.querySelector(selector.trim());
+                if (!element) {
+                    return;
+                }
+
+                element.style.display = toggle.checked ? '' : 'none';
+            });
+        };
+
+        toggle.addEventListener('change', trigger);
+        trigger();
+    });
+
+    const actionButtons = document.querySelectorAll('[data-fpml-action]');
+    const feedback = document.querySelector('#fpml-diagnostics-feedback');
+    const providerResult = document.querySelector('[data-fpml-provider-result]');
+
+    if (!actionButtons.length || typeof window.fetch !== 'function') {
+        return;
+    }
+
+    const setFeedback = (message, type) => {
+        if (!feedback) {
+            return;
+        }
+        feedback.textContent = message;
+        feedback.className = 'fpml-diagnostics-feedback' + (type ? ' is-' + type : '');
+    };
+
+    const renderProviderResult = (data) => {
+        if (!providerResult) {
+            return;
+        }
+
+        providerResult.innerHTML = '';
+
+        if (!data || !data.success) {
+            return;
+        }
+
+        const list = document.createElement('dl');
+        list.className = 'fpml-provider-result__metrics';
+
+        const rows = [
+            { label: 'Provider', value: data.provider || '-' },
+            { label: 'Latenza (s)', value: data.elapsed != null ? Number(data.elapsed).toFixed(3) : '0.000' },
+            { label: 'Caratteri', value: data.characters != null ? data.characters : 0 },
+            { label: 'Costo stimato', value: data.estimated_cost != null ? Number(data.estimated_cost).toFixed(4) + ' €' : '0.0000 €' },
+        ];
+
+        rows.forEach((row) => {
+            const dt = document.createElement('dt');
+            dt.textContent = row.label;
+            const dd = document.createElement('dd');
+            dd.textContent = row.value;
+            list.appendChild(dt);
+            list.appendChild(dd);
+        });
+
+        providerResult.appendChild(list);
+
+        if (data.sample) {
+            const sampleTitle = document.createElement('h3');
+            sampleTitle.className = 'fpml-provider-result__title';
+            sampleTitle.textContent = 'Testo di partenza';
+            const sample = document.createElement('pre');
+            sample.className = 'fpml-provider-result__text';
+            sample.textContent = data.sample;
+            providerResult.appendChild(sampleTitle);
+            providerResult.appendChild(sample);
+        }
+
+        if (data.translation) {
+            const translationTitle = document.createElement('h3');
+            translationTitle.className = 'fpml-provider-result__title';
+            translationTitle.textContent = 'Traduzione';
+            const translation = document.createElement('pre');
+            translation.className = 'fpml-provider-result__text';
+            translation.textContent = data.translation;
+            providerResult.appendChild(translationTitle);
+            providerResult.appendChild(translation);
+        }
+    };
+
+    actionButtons.forEach((button) => {
+        button.addEventListener('click', async () => {
+            const endpoint = button.getAttribute('data-endpoint');
+            const nonce = button.getAttribute('data-nonce') || '';
+            const action = button.getAttribute('data-fpml-action');
+
+            if (!endpoint) {
+                return;
+            }
+
+            button.disabled = true;
+            setFeedback(button.getAttribute('data-working-message') || 'Richiesta in corso…', 'info');
+
+            try {
+                const response = await fetch(endpoint, {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-WP-Nonce': nonce,
+                    },
+                    credentials: 'same-origin',
+                    body: '{}',
+                });
+
+                const payload = await response.json();
+
+                if (!response.ok || !payload || payload.success !== true) {
+                    const message = (payload && payload.message) || (payload && payload.data && payload.data.message) || 'Operazione non riuscita.';
+                    setFeedback(message, 'error');
+                    if (providerResult && action === 'test-provider') {
+                        providerResult.innerHTML = '';
+                    }
+                    return;
+                }
+
+                if (action === 'test-provider') {
+                    renderProviderResult(payload);
+                }
+
+                let message = button.getAttribute('data-success-message') || 'Operazione completata.';
+
+                if (action === 'run-queue' && payload.summary) {
+                    const summary = payload.summary;
+                    const processed = Number(summary.processed || 0);
+                    const claimed = Number(summary.claimed || 0);
+                    const skipped = Number(summary.skipped || 0);
+                    const errors = Number(summary.errors || 0);
+                    message = `Batch completato: ${processed}/${claimed} processati, ${skipped} saltati, ${errors} errori.`;
+                }
+
+                if (action === 'reindex' && payload.summary) {
+                    const summary = payload.summary;
+                    message = `Reindex: ${summary.posts_scanned || 0} post, ${summary.terms_scanned || 0} termini, ${summary.menus_synced || 0} menu.`;
+                }
+
+                setFeedback(message, 'success');
+            } catch (error) {
+                setFeedback(error && error.message ? error.message : 'Errore di rete imprevisto.', 'error');
+                if (providerResult && action === 'test-provider') {
+                    providerResult.innerHTML = '';
+                }
+            } finally {
+                button.disabled = false;
+            }
+        });
+    });
+})();

--- a/fp-multilanguage/cli/class-cli.php
+++ b/fp-multilanguage/cli/class-cli.php
@@ -1,0 +1,220 @@
+<?php
+/**
+ * WP-CLI integration for FP Multilanguage.
+ *
+ * @package FP_Multilanguage
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+        exit;
+}
+
+if ( defined( 'WP_CLI' ) && WP_CLI ) {
+        /**
+         * Manage the translation queue from the command line.
+         *
+         * @since 0.2.0
+         */
+        class FPML_CLI_Queue_Command extends WP_CLI_Command {
+                /**
+                 * Ensure queue commands are available when assisted mode is disabled.
+                 *
+                 * @since 0.2.0
+                 *
+                 * @return void
+                 */
+                protected function ensure_queue_available() {
+                        $plugin = FPML_Plugin::instance();
+
+                        if ( $plugin->is_assisted_mode() ) {
+                                WP_CLI::error( __( 'Modalità assistita attiva (WPML/Polylang): la coda interna di FP Multilanguage è disabilitata.', 'fp-multilanguage' ) );
+                        }
+                }
+
+                /**
+                 * Display queue status and scheduled events.
+                 *
+                 * @since 0.2.0
+                 *
+                 * @return void
+                 */
+                public function status( $args, $assoc_args ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+                        $this->ensure_queue_available();
+
+                        $queue      = FPML_Queue::instance();
+                        $processor  = FPML_Processor::instance();
+                        $state_data = $queue->get_state_counts();
+
+                        $rows   = array();
+                        $states = array( 'pending', 'translating', 'outdated', 'done', 'error', 'skipped' );
+
+                        foreach ( $states as $state ) {
+                                $rows[] = array(
+                                        'stato'  => $state,
+                                        'totale' => isset( $state_data[ $state ] ) ? (int) $state_data[ $state ] : 0,
+                                );
+                        }
+
+                        if ( empty( $rows ) ) {
+                                WP_CLI::log( 'Nessun job presente nella coda.' );
+                        } else {
+                                WP_CLI\Utils\format_items( 'table', $rows, array( 'stato', 'totale' ) );
+                        }
+
+                        $events = array(
+                                'fpml_run_queue'       => wp_next_scheduled( 'fpml_run_queue' ),
+                                'fpml_retry_failed'    => wp_next_scheduled( 'fpml_retry_failed' ),
+                                'fpml_resync_outdated' => wp_next_scheduled( 'fpml_resync_outdated' ),
+                        );
+
+                        foreach ( $events as $hook => $timestamp ) {
+                                if ( $timestamp ) {
+                                        WP_CLI::line( sprintf( '%s: %s', $hook, date_i18n( 'Y-m-d H:i:s', $timestamp ) ) );
+                                } else {
+                                        WP_CLI::line( sprintf( '%s: non programmato', $hook ) );
+                                }
+                        }
+
+                        WP_CLI::line( sprintf( 'Lock processor: %s', $processor->is_locked() ? 'attivo' : 'libero' ) );
+                }
+
+                /**
+                 * Run a single processing batch.
+                 *
+                 * @since 0.2.0
+                 *
+                 * @return void
+                 */
+                public function run( $args, $assoc_args ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+                        $this->ensure_queue_available();
+
+                        $processor = FPML_Processor::instance();
+                        $result    = $processor->run_queue();
+
+                        if ( is_wp_error( $result ) ) {
+                                WP_CLI::error( $result->get_error_message() );
+                        }
+
+                        if ( empty( $result['claimed'] ) ) {
+                                WP_CLI::success( 'Nessun job disponibile in coda.' );
+
+                                return;
+                        }
+
+                        WP_CLI::success(
+                                sprintf(
+                                        'Batch completato: %d processati, %d saltati, %d errori su %d job.',
+                                        isset( $result['processed'] ) ? (int) $result['processed'] : 0,
+                                        isset( $result['skipped'] ) ? (int) $result['skipped'] : 0,
+                                        isset( $result['errors'] ) ? (int) $result['errors'] : 0,
+                                        isset( $result['claimed'] ) ? (int) $result['claimed'] : 0
+                                )
+                        );
+                }
+
+                /**
+                 * Reset stuck jobs and release the processor lock.
+                 *
+                 * @since 0.2.0
+                 *
+                 * @return void
+                 */
+                public function reset( $args, $assoc_args ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+                        $this->ensure_queue_available();
+
+                        $processor = FPML_Processor::instance();
+                        $queue     = FPML_Queue::instance();
+
+                        $processor->force_release_lock();
+                        $reset = $queue->reset_states( array( 'translating' ) );
+
+                        WP_CLI::success( sprintf( 'Lock rilasciato. Job ripristinati in pending: %d', (int) $reset ) );
+                }
+
+                /**
+                 * Reindex posts, terms and menus ensuring queue coverage.
+                 *
+                 * @since 0.2.0
+                 *
+                 * @return void
+                 */
+                public function reindex( $args, $assoc_args ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+                        $this->ensure_queue_available();
+
+                        $plugin  = FPML_Plugin::instance();
+                        $summary = $plugin->reindex_content();
+
+                        if ( is_wp_error( $summary ) ) {
+                                WP_CLI::error( $summary->get_error_message() );
+                        }
+
+                        WP_CLI::success(
+                                sprintf(
+                                        'Reindex completato: %1$d post analizzati (%2$d nuove traduzioni, %3$d enqueued), %4$d termini e %5$d menu sincronizzati.',
+                                        isset( $summary['posts_scanned'] ) ? (int) $summary['posts_scanned'] : 0,
+                                        isset( $summary['translations_created'] ) ? (int) $summary['translations_created'] : 0,
+                                        isset( $summary['posts_enqueued'] ) ? (int) $summary['posts_enqueued'] : 0,
+                                        isset( $summary['terms_scanned'] ) ? (int) $summary['terms_scanned'] : 0,
+                                        isset( $summary['menus_synced'] ) ? (int) $summary['menus_synced'] : 0
+                                )
+                        );
+                }
+
+                /**
+                 * Reschedule outdated jobs.
+                 *
+                 * @since 0.2.0
+                 *
+                 * @return void
+                 */
+                public function resync( $args, $assoc_args ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+                        $this->ensure_queue_available();
+
+                        $processor = FPML_Processor::instance();
+                        $updated   = $processor->resync_outdated_jobs();
+
+                        WP_CLI::success( sprintf( 'Job outdated riportati in pending: %d', (int) $updated ) );
+                }
+
+                /**
+                 * Estimate the cost of pending translations.
+                 *
+                 * @since 0.2.0
+                 *
+                 * @return void
+                 */
+                public function estimate_cost( $args, $assoc_args ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+                        $this->ensure_queue_available();
+
+                        $plugin   = FPML_Plugin::instance();
+                        $estimate = $plugin->estimate_queue_cost();
+
+                        if ( is_wp_error( $estimate ) ) {
+                                WP_CLI::error( $estimate->get_error_message() );
+                        }
+
+                        if ( empty( $estimate['jobs_scanned'] ) ) {
+                                WP_CLI::success( 'Nessun job da stimare.' );
+
+                                return;
+                        }
+
+                        $characters = isset( $estimate['characters'] ) ? (int) $estimate['characters'] : 0;
+                        $cost       = isset( $estimate['estimated_cost'] ) ? (float) $estimate['estimated_cost'] : 0.0;
+                        $jobs       = isset( $estimate['jobs_scanned'] ) ? (int) $estimate['jobs_scanned'] : 0;
+                        $words      = isset( $estimate['word_count'] ) ? (int) $estimate['word_count'] : 0;
+
+                        WP_CLI::success(
+                                sprintf(
+                                        'Caratteri stimati: %1$d — parole: %2$d — costo previsto: %3$.4f su %4$d job analizzati.',
+                                        $characters,
+                                        $words,
+                                        $cost,
+                                        $jobs
+                                )
+                        );
+                }
+        }
+
+        WP_CLI::add_command( 'fpml queue', 'FPML_CLI_Queue_Command' );
+}

--- a/fp-multilanguage/docs/BUILD-STATE.md
+++ b/fp-multilanguage/docs/BUILD-STATE.md
@@ -1,0 +1,5 @@
+# FP Multilanguage — Build State
+- Fase attuale: 14 (Diagnostics, Hardening & Documentazione) completata
+- Ultimo aggiornamento: La fase 14 introduce la dashboard Diagnostics completa (KPI coda, test provider, log recenti), i notice WP-Cron e l'hardening per la modalità assistita (WPML/Polylang) con documentazione aggiornata.
+- Note: Le fasi 1–13 coprono bootstrap, impostazioni/tab, rewrites & language, queue/logger, provider reali, diff & processor con cron/lock, hook contenuti/menu, SEO avanzato con slug e sitemap EN, scanner stringhe/glossario, browser redirect & switcher, export/import & sandbox, WP-CLI e REST admin.
+Patch release: 0.2.1 (meta strutturati + shortcode esclusi)

--- a/fp-multilanguage/docs/EXPORT-EXAMPLE.csv
+++ b/fp-multilanguage/docs/EXPORT-EXAMPLE.csv
@@ -1,0 +1,2 @@
+object_type,object_subtype,source_id,translation_id,field,status,source_url,translation_url,status_date,title
+post,page,42,84,post_content,reviewed,https://example.com/pagina-di-test,https://example.com/en/test-page,2024-07-09 10:15:00,Test Page EN

--- a/fp-multilanguage/docs/GLOSSARY-EXAMPLE.csv
+++ b/fp-multilanguage/docs/GLOSSARY-EXAMPLE.csv
@@ -1,0 +1,3 @@
+source,target,notes
+"Strategia", "Strategy", "Traduzione preferita"
+"Fatturazione", "Billing", "Termine contabile"

--- a/fp-multilanguage/docs/REST-NOTES.md
+++ b/fp-multilanguage/docs/REST-NOTES.md
@@ -1,0 +1,7 @@
+# REST Endpoints (Admin)
+
+- POST `/fpml/v1/queue/run`
+- POST `/fpml/v1/test-provider`
+- POST `/fpml/v1/reindex`
+
+Tutte le richieste richiedono nonce e capability `manage_options`.

--- a/fp-multilanguage/fp-multilanguage.php
+++ b/fp-multilanguage/fp-multilanguage.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Plugin Name: FP Multilanguage
+ * Description: Traduzione automatica IT → EN (contenuti, tassonomie, menu, SEO meta/OG/Twitter, slug) con routing /en/ o ?lang=en, coda con diff incrementale, ACF/Gutenberg, sitemap EN e redirect lingua browser. Provider reali (OpenAI, DeepL, Google, LibreTranslate). Nessun file binario.
+ * Version: 0.2.1
+ * Author: Francesco Passeri
+ * Author URI: https://francescopasseri.com
+ * Text Domain: fp-multilanguage
+ * Domain Path: /languages
+ *
+ * @package FP_Multilanguage
+ */
+
+define( 'FPML_PLUGIN_VERSION', '0.2.1' );
+define( 'FPML_PLUGIN_FILE', __FILE__ );
+define( 'FPML_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
+define( 'FPML_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
+
+autoload_fpml_files();
+
+require_once FPML_PLUGIN_DIR . 'admin/class-admin.php';
+
+if ( file_exists( FPML_PLUGIN_DIR . 'rest/class-rest-admin.php' ) ) {
+        require_once FPML_PLUGIN_DIR . 'rest/class-rest-admin.php';
+}
+
+if ( defined( 'WP_CLI' ) && WP_CLI && file_exists( FPML_PLUGIN_DIR . 'cli/class-cli.php' ) ) {
+        require_once FPML_PLUGIN_DIR . 'cli/class-cli.php';
+}
+
+/**
+ * Require plugin includes.
+ *
+ * @since 0.2.0
+ * @return void
+ */
+function autoload_fpml_files() {
+$includes_dir = FPML_PLUGIN_DIR . 'includes/';
+if ( ! is_dir( $includes_dir ) ) {
+return;
+}
+
+$iterator = new RecursiveIteratorIterator(
+new RecursiveDirectoryIterator( $includes_dir, FilesystemIterator::SKIP_DOTS ),
+RecursiveIteratorIterator::SELF_FIRST
+);
+
+foreach ( $iterator as $file ) {
+if ( 'php' !== strtolower( $file->getExtension() ) ) {
+continue;
+}
+
+require_once $file->getPathname();
+}
+}
+
+/**
+ * Initialize the plugin.
+ *
+ * @since 0.2.0
+ * @return void
+ */
+function fpml_run_plugin() {
+if ( ! class_exists( 'FPML_Plugin' ) ) {
+return;
+}
+
+FPML_Plugin::instance();
+}
+
+add_action( 'plugins_loaded', 'fpml_run_plugin' );
+
+register_activation_hook( __FILE__, array( 'FPML_Plugin', 'activate' ) );
+register_deactivation_hook( __FILE__, array( 'FPML_Plugin', 'deactivate' ) );

--- a/fp-multilanguage/includes/class-content-diff.php
+++ b/fp-multilanguage/includes/class-content-diff.php
@@ -1,0 +1,430 @@
+<?php
+/**
+ * Content diff helper to perform incremental translation while preserving markup.
+ *
+ * @package FP_Multilanguage
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+        exit;
+}
+
+/**
+ * Provide utilities to compute textual diffs that respect HTML/shortcodes boundaries.
+ *
+ * @since 0.2.0
+ */
+class FPML_Content_Diff {
+        const SHORTCODE_PLACEHOLDER_PREFIX = '__FPML_SC_PLACEHOLDER_';
+        const SHORTCODE_PLACEHOLDER_REGEX  = '/__FPML_SC_PLACEHOLDER_[A-Z0-9]{12}__/';
+        /**
+         * Singleton instance.
+         *
+         * @var FPML_Content_Diff|null
+         */
+        protected static $instance = null;
+
+        /**
+         * Retrieve singleton instance.
+         *
+         * @since 0.2.0
+         *
+         * @return FPML_Content_Diff
+         */
+        public static function instance() {
+                if ( null === self::$instance ) {
+                        self::$instance = new self();
+                }
+
+                return self::$instance;
+        }
+
+        /**
+         * Tokenize content into translatable text and structural tokens.
+         *
+         * @since 0.2.0
+         *
+         * @param string $content Raw HTML/content.
+         *
+         * @return array Array of tokens.
+         */
+        public function tokenize( $content ) {
+                $content = is_string( $content ) ? $content : '';
+
+                if ( '' === $content ) {
+                        return array();
+                }
+
+                $shortcode_regex = function_exists( 'get_shortcode_regex' ) ? get_shortcode_regex() : '';
+                $pattern         = $shortcode_regex ? '/(' . $shortcode_regex . '|<[^>]+>)/' : '/(<[^>]+>)/';
+
+                $parts = preg_split( $pattern, $content, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY );
+
+                $tokens      = array();
+                $text_index  = 0;
+                $shortcode_pattern = $shortcode_regex ? '/^' . $shortcode_regex . '$/' : '/^$/';
+
+                foreach ( $parts as $part ) {
+                        if ( '' === $part ) {
+                                continue;
+                        }
+
+                        if ( '<' === $part[0] ) {
+                                $tokens[] = array(
+                                        'type'  => 'tag',
+                                        'value' => $part,
+                                );
+                                continue;
+                        }
+
+                        if ( preg_match( self::SHORTCODE_PLACEHOLDER_REGEX, $part ) ) {
+                                $tokens[] = array(
+                                        'type'  => 'placeholder',
+                                        'value' => $part,
+                                );
+                                continue;
+                        }
+
+                        if ( $shortcode_regex && preg_match( $shortcode_pattern, $part ) ) {
+                                $tokens[] = array(
+                                        'type'  => 'shortcode',
+                                        'value' => $part,
+                                );
+                                continue;
+                        }
+
+                        $tokens[] = $this->prepare_text_token( $part, $text_index );
+                        $text_index++;
+                }
+
+                return $tokens;
+        }
+
+        /**
+         * Extract map of text segments from tokenized content.
+         *
+         * @since 0.2.0
+         *
+         * @param array $tokens Tokens previously produced by tokenize().
+         *
+         * @return array Map of index => segment data.
+         */
+        public function extract_text_map( $tokens ) {
+                $map = array();
+
+                foreach ( $tokens as $token ) {
+                        if ( 'text' !== $token['type'] ) {
+                                continue;
+                        }
+
+                        $index = (int) $token['index'];
+                        $map[ $index ] = $token;
+                }
+
+                return $map;
+        }
+
+        /**
+         * Normalize shortcode slugs to compare against the exclusion list.
+         *
+         * @since 0.2.1
+         *
+         * @param array $shortcodes Raw shortcode identifiers.
+         *
+         * @return array
+         */
+        protected function normalize_excluded_shortcodes( $shortcodes ) {
+                if ( empty( $shortcodes ) ) {
+                        return array();
+                }
+
+                $normalized = array();
+
+                foreach ( (array) $shortcodes as $shortcode ) {
+                        if ( ! is_string( $shortcode ) ) {
+                                continue;
+                        }
+
+                        $slug = strtolower( trim( preg_replace( '/[^a-z0-9_-]/i', '', $shortcode ) ) );
+
+                        if ( '' !== $slug ) {
+                                $normalized[] = $slug;
+                        }
+                }
+
+                return array_values( array_unique( $normalized ) );
+        }
+
+        /**
+         * Replace excluded shortcode instances with placeholders.
+         *
+         * @since 0.2.1
+         *
+         * @param string $content   Content to inspect.
+         * @param array  $shortcodes Shortcode slugs to exclude.
+         *
+         * @return array Tuple containing the masked content and the placeholder map.
+         */
+        protected function mask_excluded_shortcodes( $content, $shortcodes ) {
+                $content = is_string( $content ) ? $content : '';
+
+                if ( '' === $content || empty( $shortcodes ) ) {
+                        return array( $content, array() );
+                }
+
+                $map     = array();
+                $pattern = '/\[([a-zA-Z0-9_\-]+)([^\]]*)\](?:.*?\[\/\1\])?/s';
+
+                $masked = preg_replace_callback(
+                        $pattern,
+                        function( $matches ) use ( $shortcodes, &$map ) {
+                                $tag = strtolower( $matches[1] );
+
+                                if ( ! in_array( $tag, $shortcodes, true ) ) {
+                                        return $matches[0];
+                                }
+
+                                $index       = count( $map );
+                                $hash        = strtoupper( substr( md5( $matches[0] . '|' . $index ), 0, 12 ) );
+                                $placeholder = self::SHORTCODE_PLACEHOLDER_PREFIX . $hash . '__';
+
+                                while ( isset( $map[ $placeholder ] ) ) {
+                                        $index++;
+                                        $hash        = strtoupper( substr( md5( $matches[0] . '|' . $index ), 0, 12 ) );
+                                        $placeholder = self::SHORTCODE_PLACEHOLDER_PREFIX . $hash . '__';
+                                }
+
+                                $map[ $placeholder ] = $matches[0];
+
+                                return $placeholder;
+                        },
+                        $content
+                );
+
+                if ( null === $masked ) {
+                        return array( $content, $map );
+                }
+
+                return array( $masked, $map );
+        }
+
+        /**
+         * Prepare text for provider requests by masking excluded shortcodes.
+         *
+         * @since 0.2.1
+         *
+         * @param string $content   Text chunk to process.
+         * @param array  $shortcodes Shortcode slugs to exclude from translation.
+         *
+         * @return array Tuple containing the masked content and the placeholder map.
+         */
+        public function prepare_text_for_provider( $content, $shortcodes ) {
+                $normalized = $this->normalize_excluded_shortcodes( $shortcodes );
+
+                if ( empty( $normalized ) ) {
+                        $content = is_string( $content ) ? $content : '';
+
+                        return array( $content, array() );
+                }
+
+                return $this->mask_excluded_shortcodes( $content, $normalized );
+        }
+
+        /**
+         * Restore excluded shortcode placeholders to their original markup.
+         *
+         * @since 0.2.1
+         *
+         * @param string $content Content containing placeholders.
+         * @param array  $map     Placeholder map generated during masking.
+         *
+         * @return string
+         */
+        public function restore_placeholders( $content, $map ) {
+                $content = is_string( $content ) ? $content : '';
+
+                if ( '' === $content || empty( $map ) ) {
+                        return $content;
+                }
+
+                $replacements = array();
+
+                foreach ( (array) $map as $placeholder => $original ) {
+                        if ( ! is_string( $placeholder ) || '' === $placeholder ) {
+                                continue;
+                        }
+
+                        $replacements[ $placeholder ] = is_string( $original ) ? $original : '';
+                }
+
+                if ( empty( $replacements ) ) {
+                        return $content;
+                }
+
+                return strtr( $content, $replacements );
+        }
+
+        /**
+         * Determine which segments changed between source and target content.
+         *
+         * @since 0.2.0
+         *
+         * @param string $source  Source text (Italiano).
+         * @param string $target  Existing translation (English).
+         * @param array  $context Additional diff configuration.
+         *
+         * @return array Diff structure containing segments to translate and helpers for merge.
+         */
+        public function calculate_diff( $source, $target, $context = array() ) {
+                $source = is_string( $source ) ? $source : (string) $source;
+                $target = is_string( $target ) ? $target : (string) $target;
+
+                $excluded_shortcodes = array();
+                if ( isset( $context['excluded_shortcodes'] ) ) {
+                        $excluded_shortcodes = $this->normalize_excluded_shortcodes( $context['excluded_shortcodes'] );
+                }
+
+                $placeholder_map = array();
+
+                if ( ! empty( $excluded_shortcodes ) ) {
+                        list( $source, $source_map ) = $this->mask_excluded_shortcodes( $source, $excluded_shortcodes );
+                        list( $target, $target_map ) = $this->mask_excluded_shortcodes( $target, $excluded_shortcodes );
+                        $placeholder_map          = $source_map + $target_map;
+                }
+
+                $source_tokens = $this->tokenize( $source );
+                $target_tokens = $this->tokenize( $target );
+
+                $source_map = $this->extract_text_map( $source_tokens );
+                $target_map = $this->extract_text_map( $target_tokens );
+
+                $to_translate = array();
+
+                foreach ( $source_map as $index => $token ) {
+                        $source_normalized = $this->normalize_for_diff( $token['text'] );
+                        $target_token      = isset( $target_map[ $index ] ) ? $target_map[ $index ] : null;
+                        $target_normalized = $target_token ? $this->normalize_for_diff( $target_token['text'] ) : '';
+
+                        if ( '' === $source_normalized ) {
+                                continue;
+                        }
+
+                        if ( $source_normalized !== $target_normalized ) {
+                                $to_translate[ $index ] = $token['text'];
+                        }
+                }
+
+                return array(
+                        'source_tokens'   => $source_tokens,
+                        'target_tokens'   => $target_tokens,
+                        'source_map'      => $source_map,
+                        'target_map'      => $target_map,
+                        'segments'        => $to_translate,
+                        'placeholder_map' => $placeholder_map,
+                );
+        }
+
+        /**
+         * Merge translated segments back into the original structure.
+         *
+         * @since 0.2.0
+         *
+         * @param array $source_tokens    Tokens generated from Italian source.
+         * @param array $target_map       Existing translation text map.
+         * @param array $translations     Map of index => translated string.
+         * @param array $placeholder_map  Placeholder map for excluded shortcodes.
+         *
+         * @return string Reconstructed content for the translated entity.
+         */
+        public function rebuild( $source_tokens, $target_map, $translations, $placeholder_map = array() ) {
+                $output = array();
+
+                foreach ( $source_tokens as $token ) {
+                        if ( 'text' !== $token['type'] ) {
+                                $output[] = $token['value'];
+                                continue;
+                        }
+
+                        $index = (int) $token['index'];
+
+                        if ( isset( $translations[ $index ] ) ) {
+                                $value = $translations[ $index ];
+                        } elseif ( isset( $target_map[ $index ] ) ) {
+                                $value = $target_map[ $index ]['text'];
+                        } else {
+                                $value = $token['text'];
+                        }
+
+                        $value     = is_string( $value ) ? $value : '';
+                        $value     = $this->restore_whitespace( $value, $token );
+                        $output[] = $value;
+                }
+
+                $result = implode( '', $output );
+
+                return $this->restore_placeholders( $result, $placeholder_map );
+        }
+
+        /**
+         * Prepare a token entry for text segments.
+         *
+         * @since 0.2.0
+         *
+         * @param string $text       Raw text segment.
+         * @param int    $text_index Running index.
+         *
+         * @return array Token data structure.
+         */
+        protected function prepare_text_token( $text, $text_index ) {
+                $text = (string) $text;
+
+                preg_match( '/^(\s*)(.*?)(\s*)$/s', $text, $matches );
+
+                $leading = isset( $matches[1] ) ? $matches[1] : '';
+                $core    = isset( $matches[2] ) ? $matches[2] : '';
+                $trailing = isset( $matches[3] ) ? $matches[3] : '';
+
+                return array(
+                        'type'   => 'text',
+                        'value'  => $text,
+                        'text'   => $core,
+                        'index'  => (int) $text_index,
+                        'prefix' => $leading,
+                        'suffix' => $trailing,
+                );
+        }
+
+        /**
+         * Restore whitespace around a translated string.
+         *
+         * @since 0.2.0
+         *
+         * @param string $text   Translated text.
+         * @param array  $token  Original token metadata.
+         *
+         * @return string
+         */
+        protected function restore_whitespace( $text, $token ) {
+                $prefix = isset( $token['prefix'] ) ? $token['prefix'] : '';
+                $suffix = isset( $token['suffix'] ) ? $token['suffix'] : '';
+
+                return $prefix . $text . $suffix;
+        }
+
+        /**
+         * Normalize strings for comparison purposes.
+         *
+         * @since 0.2.0
+         *
+         * @param string $text Text to normalize.
+         *
+         * @return string
+         */
+        protected function normalize_for_diff( $text ) {
+                $text = is_string( $text ) ? $text : '';
+                $text = wp_strip_all_tags( $text );
+                $text = preg_replace( '/\s+/u', ' ', $text );
+
+                return trim( $text );
+        }
+}

--- a/fp-multilanguage/includes/class-export-import.php
+++ b/fp-multilanguage/includes/class-export-import.php
@@ -1,0 +1,683 @@
+<?php
+/**
+ * Export and import helpers for FP Multilanguage.
+ *
+ * @package FP_Multilanguage
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+        exit;
+}
+
+/**
+ * Handle structured export/import routines and sandbox previews.
+ *
+ * @since 0.2.0
+ */
+class FPML_Export_Import {
+        /**
+         * Option key for sandbox previews storage.
+         */
+        const SANDBOX_OPTION = 'fpml_sandbox_previews';
+
+        /**
+         * Singleton instance.
+         *
+         * @var FPML_Export_Import|null
+         */
+        protected static $instance = null;
+
+        /**
+         * Queue reference.
+         *
+         * @var FPML_Queue
+         */
+        protected $queue;
+
+        /**
+         * Logger reference.
+         *
+         * @var FPML_Logger
+         */
+        protected $logger;
+
+        /**
+         * Settings reference.
+         *
+         * @var FPML_Settings
+         */
+        protected $settings;
+
+        /**
+         * Glossary manager reference.
+         *
+         * @var FPML_Glossary
+         */
+        protected $glossary;
+
+        /**
+         * Overrides manager reference.
+         *
+         * @var FPML_Strings_Override
+         */
+        protected $overrides;
+
+        /**
+         * Retrieve singleton instance.
+         *
+         * @since 0.2.0
+         *
+         * @return FPML_Export_Import
+         */
+        public static function instance() {
+                if ( null === self::$instance ) {
+                        self::$instance = new self();
+                }
+
+                return self::$instance;
+        }
+
+        /**
+         * Constructor.
+         */
+        protected function __construct() {
+                $this->queue     = FPML_Queue::instance();
+                $this->logger    = FPML_Logger::instance();
+                $this->settings  = FPML_Settings::instance();
+                $this->glossary  = FPML_Glossary::instance();
+                $this->overrides = FPML_Strings_Override::instance();
+        }
+
+        /**
+         * Export translation status state.
+         *
+         * @since 0.2.0
+         *
+         * @param string $format Format: json|csv.
+         *
+         * @return string
+         */
+        public function export_translation_state( $format = 'json' ) {
+                $entries = $this->get_translation_state_entries();
+                $format  = in_array( $format, array( 'json', 'csv' ), true ) ? $format : 'json';
+
+                if ( 'csv' === $format ) {
+                        return $this->convert_entries_to_csv( $entries );
+                }
+
+                return wp_json_encode( $entries );
+        }
+
+        /**
+         * Import translation state entries.
+         *
+         * @since 0.2.0
+         *
+         * @param string $payload Raw payload.
+         * @param string $format  json|csv.
+         *
+         * @return int Number of imported rows.
+         */
+        public function import_translation_state( $payload, $format = 'json' ) {
+                $format  = in_array( $format, array( 'json', 'csv' ), true ) ? $format : 'json';
+                $payload = is_string( $payload ) ? trim( $payload ) : '';
+
+                if ( '' === $payload ) {
+                        return 0;
+                }
+
+                if ( 'csv' === $format ) {
+                        $rows = $this->parse_csv_rows( $payload );
+                } else {
+                        $rows = json_decode( $payload, true );
+                }
+
+                if ( ! is_array( $rows ) ) {
+                        return 0;
+                }
+
+                $imported = 0;
+
+                foreach ( $rows as $row ) {
+                        if ( empty( $row['object_type'] ) || empty( $row['field'] ) || empty( $row['status'] ) ) {
+                                continue;
+                        }
+
+                        $object_type = sanitize_key( $row['object_type'] );
+                        $field       = sanitize_key( $row['field'] );
+                        $status      = sanitize_key( $row['status'] );
+                        $target_id   = isset( $row['translation_id'] ) ? absint( $row['translation_id'] ) : 0;
+
+                        if ( ! $target_id ) {
+                                continue;
+                        }
+
+                        $meta_key = '_fpml_status_' . $field;
+
+                        switch ( $object_type ) {
+                                case 'post':
+                                case 'menu':
+                                        update_post_meta( $target_id, $meta_key, $status );
+                                        $imported++;
+                                        break;
+                                case 'term':
+                                        update_term_meta( $target_id, $meta_key, $status );
+                                        $imported++;
+                                        break;
+                        }
+                }
+
+                return $imported;
+        }
+
+        /**
+         * Export logger entries.
+         *
+         * @since 0.2.0
+         *
+         * @param string $format json|csv.
+         *
+         * @return string
+         */
+        public function export_logs( $format = 'json' ) {
+                $format = in_array( $format, array( 'json', 'csv' ), true ) ? $format : 'json';
+                $logs   = $this->logger->get_logs( 200 );
+
+                if ( 'csv' === $format ) {
+                        $rows   = array();
+                        $rows[] = array( 'timestamp', 'level', 'message', 'context' );
+
+                        foreach ( $logs as $log ) {
+                                $rows[] = array(
+                                        isset( $log['timestamp'] ) ? $log['timestamp'] : '',
+                                        isset( $log['level'] ) ? $log['level'] : 'info',
+                                        isset( $log['message'] ) ? $log['message'] : '',
+                                        isset( $log['context'] ) ? wp_json_encode( $log['context'] ) : '',
+                                );
+                        }
+
+                        return $this->convert_rows_to_csv( $rows );
+                }
+
+                return wp_json_encode( $logs );
+        }
+
+        /**
+         * Import log entries.
+         *
+         * @since 0.2.0
+         *
+         * @param string $payload Payload body.
+         * @param string $format  json|csv.
+         *
+         * @return int Imported count.
+         */
+        public function import_logs( $payload, $format = 'json' ) {
+                $format  = in_array( $format, array( 'json', 'csv' ), true ) ? $format : 'json';
+                $payload = is_string( $payload ) ? trim( $payload ) : '';
+
+                if ( '' === $payload ) {
+                        return 0;
+                }
+
+                if ( 'csv' === $format ) {
+                        $rows = $this->parse_csv_rows( $payload );
+                } else {
+                        $rows = json_decode( $payload, true );
+                }
+
+                if ( ! is_array( $rows ) ) {
+                        return 0;
+                }
+
+                $normalized = array();
+
+                foreach ( $rows as $row ) {
+                        if ( empty( $row['message'] ) ) {
+                                continue;
+                        }
+
+                        $normalized[] = array(
+                                'timestamp' => isset( $row['timestamp'] ) ? sanitize_text_field( $row['timestamp'] ) : current_time( 'mysql', true ),
+                                'level'     => isset( $row['level'] ) ? sanitize_key( $row['level'] ) : 'info',
+                                'message'   => sanitize_textarea_field( $row['message'] ),
+                                'context'   => isset( $row['context'] ) ? $this->normalize_context_column( $row['context'] ) : array(),
+                        );
+                }
+
+                if ( empty( $normalized ) ) {
+                        return 0;
+                }
+
+                return $this->logger->import_logs( $normalized );
+        }
+
+        /**
+         * Retrieve stored sandbox previews.
+         *
+         * @since 0.2.0
+         *
+         * @return array
+         */
+        public function get_sandbox_previews() {
+                $previews = get_option( self::SANDBOX_OPTION, array() );
+
+                if ( ! is_array( $previews ) ) {
+                        return array();
+                }
+
+                return $previews;
+        }
+
+        /**
+         * Record a sandbox preview entry.
+         *
+         * @since 0.2.0
+         *
+         * @param array $data Preview data.
+         *
+         * @return void
+         */
+        public function record_sandbox_preview( $data ) {
+                $entry = array(
+                        'timestamp'         => current_time( 'mysql', true ),
+                        'object_type'       => isset( $data['object_type'] ) ? sanitize_key( $data['object_type'] ) : 'post',
+                        'object_id'         => isset( $data['object_id'] ) ? absint( $data['object_id'] ) : 0,
+                        'field'             => isset( $data['field'] ) ? sanitize_text_field( $data['field'] ) : '',
+                        'characters'        => isset( $data['characters'] ) ? absint( $data['characters'] ) : 0,
+                        'word_count'        => isset( $data['word_count'] ) ? absint( $data['word_count'] ) : 0,
+                        'estimated_cost'    => isset( $data['estimated_cost'] ) ? (float) $data['estimated_cost'] : 0.0,
+                        'source_excerpt'    => isset( $data['source_excerpt'] ) ? $this->clean_preview_text( $data['source_excerpt'] ) : '',
+                        'translated_excerpt'=> isset( $data['translated_excerpt'] ) ? $this->clean_preview_text( $data['translated_excerpt'] ) : '',
+                        'job_id'            => isset( $data['job_id'] ) ? absint( $data['job_id'] ) : 0,
+                        'provider'          => isset( $data['provider'] ) ? sanitize_text_field( $data['provider'] ) : '',
+                        'source_url'        => isset( $data['source_url'] ) ? esc_url_raw( $data['source_url'] ) : '',
+                        'translation_url'   => isset( $data['translation_url'] ) ? esc_url_raw( $data['translation_url'] ) : '',
+                );
+
+                $previews = $this->get_sandbox_previews();
+                array_unshift( $previews, $entry );
+
+                if ( count( $previews ) > 20 ) {
+                        $previews = array_slice( $previews, 0, 20 );
+                }
+
+                update_option( self::SANDBOX_OPTION, $previews, false );
+        }
+
+        /**
+         * Clear sandbox previews.
+         *
+         * @since 0.2.0
+         *
+         * @return void
+         */
+        public function clear_sandbox_previews() {
+                delete_option( self::SANDBOX_OPTION );
+        }
+
+        /**
+         * Normalize context column from CSV imports.
+         *
+         * @since 0.2.0
+         *
+         * @param mixed $context Raw context.
+         *
+         * @return array
+         */
+        protected function normalize_context_column( $context ) {
+                if ( empty( $context ) ) {
+                        return array();
+                }
+
+                if ( is_array( $context ) ) {
+                        return $context;
+                }
+
+                $decoded = json_decode( (string) $context, true );
+
+                if ( is_array( $decoded ) ) {
+                        return $decoded;
+                }
+
+                return array();
+        }
+
+        /**
+         * Clean preview text to avoid leaking HTML.
+         *
+         * @since 0.2.0
+         *
+         * @param string $text Raw text.
+         *
+         * @return string
+         */
+        protected function clean_preview_text( $text ) {
+                $text = wp_strip_all_tags( (string) $text );
+                $text = preg_replace( '/\s+/u', ' ', $text );
+
+                return trim( wp_trim_words( $text, 40, '…' ) );
+        }
+
+        /**
+         * Retrieve translation state entries for posts, terms and menus.
+         *
+         * @since 0.2.0
+         *
+         * @return array
+         */
+        protected function get_translation_state_entries() {
+                $entries = array();
+
+                $entries = array_merge( $entries, $this->collect_post_status_rows() );
+                $entries = array_merge( $entries, $this->collect_term_status_rows() );
+                $entries = array_merge( $entries, $this->collect_menu_status_rows() );
+
+                return $entries;
+        }
+
+        /**
+         * Collect post status rows.
+         *
+         * @since 0.2.0
+         *
+         * @return array
+         */
+        protected function collect_post_status_rows() {
+                $rows = array();
+
+                $args = array(
+                        'post_type'      => 'any',
+                        'posts_per_page' => -1,
+                        'post_status'    => array( 'publish', 'draft', 'pending', 'future', 'private' ),
+                        'meta_key'       => '_fpml_is_translation',
+                        'meta_value'     => 1,
+                        'fields'         => 'ids',
+                );
+
+                $ids = get_posts( $args );
+
+                foreach ( $ids as $translation_id ) {
+                        $translation_id = (int) $translation_id;
+                        $post           = get_post( $translation_id );
+
+                        if ( ! $post ) {
+                                continue;
+                        }
+
+                        $meta      = get_post_meta( $translation_id );
+                        $source_id = (int) get_post_meta( $translation_id, '_fpml_pair_source_id', true );
+                        $source    = $source_id ? get_permalink( $source_id ) : '';
+                        $target    = get_permalink( $translation_id );
+
+                        foreach ( $meta as $meta_key => $values ) {
+                                if ( 0 !== strpos( $meta_key, '_fpml_status_' ) ) {
+                                        continue;
+                                }
+
+                                $status = end( $values );
+                                $status = sanitize_key( $status );
+                                $field  = substr( $meta_key, 13 );
+
+                                $rows[] = array(
+                                        'object_type'      => 'post',
+                                        'object_subtype'   => $post->post_type,
+                                        'source_id'        => $source_id,
+                                        'translation_id'   => $translation_id,
+                                        'field'            => $field,
+                                        'status'           => $status,
+                                        'source_url'       => $source ? esc_url_raw( $source ) : '',
+                                        'translation_url'  => $target ? esc_url_raw( $target ) : '',
+                                        'status_date'      => $this->get_status_timestamp( $meta, $meta_key, get_post_modified_gmt( $translation_id ) ),
+                                        'title'            => $this->clean_preview_text( get_the_title( $translation_id ) ),
+                                );
+                        }
+                }
+
+                return $rows;
+        }
+
+        /**
+         * Collect term status rows.
+         *
+         * @since 0.2.0
+         *
+         * @return array
+         */
+        protected function collect_term_status_rows() {
+                $rows       = array();
+                $taxonomies = get_taxonomies( array( 'public' => true ), 'names' );
+
+                foreach ( $taxonomies as $taxonomy ) {
+                        $terms = get_terms(
+                                array(
+                                        'taxonomy'   => $taxonomy,
+                                        'hide_empty' => false,
+                                        'meta_query' => array(
+                                                array(
+                                                        'key'   => '_fpml_is_translation',
+                                                        'value' => 1,
+                                                ),
+                                        ),
+                                )
+                        );
+
+                        if ( is_wp_error( $terms ) ) {
+                                continue;
+                        }
+
+                        foreach ( $terms as $term ) {
+                                $meta      = get_term_meta( $term->term_id );
+                                $source_id = (int) get_term_meta( $term->term_id, '_fpml_pair_source_id', true );
+                                $source    = $source_id ? get_term_link( (int) $source_id, $taxonomy ) : '';
+                                $target    = get_term_link( $term, $taxonomy );
+
+                                foreach ( $meta as $meta_key => $values ) {
+                                        if ( 0 !== strpos( $meta_key, '_fpml_status_' ) ) {
+                                                continue;
+                                        }
+
+                                        $status = end( $values );
+                                        $status = sanitize_key( $status );
+                                        $field  = substr( $meta_key, 13 );
+
+                                        $rows[] = array(
+                                                'object_type'      => 'term',
+                                                'object_subtype'   => $taxonomy,
+                                                'source_id'        => $source_id,
+                                                'translation_id'   => (int) $term->term_id,
+                                                'field'            => $field,
+                                                'status'           => $status,
+                                                'source_url'       => ! is_wp_error( $source ) ? esc_url_raw( $source ) : '',
+                                                'translation_url'  => ! is_wp_error( $target ) ? esc_url_raw( $target ) : '',
+                                                'status_date'      => $this->get_status_timestamp( $meta, $meta_key, gmdate( 'Y-m-d H:i:s' ) ),
+                                                'title'            => $this->clean_preview_text( $term->name ),
+                                        );
+                                }
+                        }
+                }
+
+                return $rows;
+        }
+
+        /**
+         * Collect menu status rows.
+         *
+         * @since 0.2.0
+         *
+         * @return array
+         */
+        protected function collect_menu_status_rows() {
+                $rows = array();
+
+                $items = get_posts(
+                        array(
+                                'post_type'      => 'nav_menu_item',
+                                'posts_per_page' => -1,
+                                'post_status'    => array( 'publish', 'draft', 'pending', 'private' ),
+                                'meta_key'       => '_fpml_is_translation',
+                                'meta_value'     => 1,
+                                'fields'         => 'ids',
+                        )
+                );
+
+                foreach ( $items as $item_id ) {
+                        $item_id    = (int) $item_id;
+                        $meta       = get_post_meta( $item_id );
+                        $source_id  = (int) get_post_meta( $item_id, '_fpml_pair_source_id', true );
+                        $source_url = $source_id ? get_post_meta( $source_id, '_menu_item_url', true ) : '';
+                        $target_url = get_post_meta( $item_id, '_menu_item_url', true );
+                        $title      = get_post_meta( $item_id, '_menu_item_title', true );
+
+                        foreach ( $meta as $meta_key => $values ) {
+                                if ( 0 !== strpos( $meta_key, '_fpml_status_' ) ) {
+                                        continue;
+                                }
+
+                                $status = end( $values );
+                                $status = sanitize_key( $status );
+                                $field  = substr( $meta_key, 13 );
+
+                                $rows[] = array(
+                                        'object_type'      => 'menu',
+                                        'object_subtype'   => 'nav_menu_item',
+                                        'source_id'        => $source_id,
+                                        'translation_id'   => $item_id,
+                                        'field'            => $field,
+                                        'status'           => $status,
+                                        'source_url'       => $source_url ? esc_url_raw( $source_url ) : '',
+                                        'translation_url'  => $target_url ? esc_url_raw( $target_url ) : '',
+                                        'status_date'      => get_post_modified_gmt( $item_id ),
+                                        'title'            => $this->clean_preview_text( $title ? $title : get_the_title( $item_id ) ),
+                                );
+                        }
+                }
+
+                return $rows;
+        }
+
+        /**
+         * Extract timestamp from meta or fallback.
+         *
+         * @since 0.2.0
+         *
+         * @param array  $meta       Meta array.
+         * @param string $meta_key   Status meta key.
+         * @param string $fallback   Fallback timestamp.
+         *
+         * @return string
+         */
+        protected function get_status_timestamp( $meta, $meta_key, $fallback ) {
+                $suffix = $meta_key . '_updated_at';
+
+                if ( isset( $meta[ $suffix ] ) ) {
+                        $value = end( $meta[ $suffix ] );
+                        $value = sanitize_text_field( $value );
+
+                        if ( '' !== $value ) {
+                                return $value;
+                        }
+                }
+
+                return $fallback;
+        }
+
+        /**
+         * Convert entries to CSV string.
+         *
+         * @since 0.2.0
+         *
+         * @param array $entries Rows to export.
+         *
+         * @return string
+         */
+        protected function convert_entries_to_csv( $entries ) {
+                $rows   = array();
+                $header = array( 'object_type', 'object_subtype', 'source_id', 'translation_id', 'field', 'status', 'source_url', 'translation_url', 'status_date', 'title' );
+                $rows[] = $header;
+
+                foreach ( $entries as $entry ) {
+                        $rows[] = array(
+                                isset( $entry['object_type'] ) ? $entry['object_type'] : '',
+                                isset( $entry['object_subtype'] ) ? $entry['object_subtype'] : '',
+                                isset( $entry['source_id'] ) ? $entry['source_id'] : '',
+                                isset( $entry['translation_id'] ) ? $entry['translation_id'] : '',
+                                isset( $entry['field'] ) ? $entry['field'] : '',
+                                isset( $entry['status'] ) ? $entry['status'] : '',
+                                isset( $entry['source_url'] ) ? $entry['source_url'] : '',
+                                isset( $entry['translation_url'] ) ? $entry['translation_url'] : '',
+                                isset( $entry['status_date'] ) ? $entry['status_date'] : '',
+                                isset( $entry['title'] ) ? $entry['title'] : '',
+                        );
+                }
+
+                return $this->convert_rows_to_csv( $rows );
+        }
+
+        /**
+         * Convert rows to CSV output.
+         *
+         * @since 0.2.0
+         *
+         * @param array $rows Rows of data.
+         *
+         * @return string
+         */
+        protected function convert_rows_to_csv( $rows ) {
+                $buffer = fopen( 'php://temp', 'w+' );
+
+                foreach ( $rows as $row ) {
+                        fputcsv( $buffer, $row );
+                }
+
+                rewind( $buffer );
+                $csv = stream_get_contents( $buffer );
+                fclose( $buffer );
+
+                return $csv;
+        }
+
+        /**
+         * Parse CSV rows into associative arrays.
+         *
+         * @since 0.2.0
+         *
+         * @param string $csv CSV payload.
+         *
+         * @return array
+         */
+        protected function parse_csv_rows( $csv ) {
+                $lines = preg_split( '/\r\n|\r|\n/', $csv );
+                $lines = array_filter( array_map( 'trim', $lines ) );
+
+                if ( empty( $lines ) ) {
+                        return array();
+                }
+
+                $header = array();
+                $rows   = array();
+
+                foreach ( $lines as $index => $line ) {
+                        $columns = str_getcsv( $line );
+
+                        if ( 0 === $index ) {
+                                $header = array_map( 'sanitize_key', $columns );
+                                continue;
+                        }
+
+                        if ( empty( $header ) ) {
+                                continue;
+                        }
+
+                        $row = array();
+
+                        foreach ( $header as $position => $key ) {
+                                $row[ $key ] = isset( $columns[ $position ] ) ? $columns[ $position ] : '';
+                        }
+
+                        $rows[] = $row;
+                }
+
+                return $rows;
+        }
+}

--- a/fp-multilanguage/includes/class-glossary.php
+++ b/fp-multilanguage/includes/class-glossary.php
@@ -1,0 +1,427 @@
+<?php
+/**
+ * Glossary manager handling custom terminology enforcement.
+ *
+ * @package FP_Multilanguage
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+        exit;
+}
+
+/**
+ * Provide storage and helpers for glossary entries.
+ *
+ * @since 0.2.0
+ */
+class FPML_Glossary {
+        /**
+         * Option name storing glossary entries.
+         */
+        const OPTION_KEY = 'fpml_glossary_entries';
+
+        /**
+         * Singleton instance.
+         *
+         * @var FPML_Glossary|null
+         */
+        protected static $instance = null;
+
+        /**
+         * Cached glossary entries.
+         *
+         * @var array
+         */
+        protected $entries = array();
+
+        /**
+         * Constructor.
+         */
+        protected function __construct() {
+                $this->entries = $this->load_entries();
+                $this->register_filters();
+        }
+
+        /**
+         * Retrieve singleton instance.
+         *
+         * @since 0.2.0
+         *
+         * @return FPML_Glossary
+         */
+        public static function instance() {
+                if ( null === self::$instance ) {
+                        self::$instance = new self();
+                }
+
+                return self::$instance;
+        }
+
+        /**
+         * Register glossary filters so providers can enforce terminology.
+         *
+         * @since 0.2.0
+         *
+         * @return void
+         */
+        protected function register_filters() {
+                add_filter( 'fpml_glossary_pre_translate', array( $this, 'filter_pre_translate' ), 10, 4 );
+                add_filter( 'fpml_glossary_post_translate', array( $this, 'filter_post_translate' ), 10, 4 );
+        }
+
+        /**
+         * Load glossary entries from storage.
+         *
+         * @since 0.2.0
+         *
+         * @return array
+         */
+        protected function load_entries() {
+                $stored = get_option( self::OPTION_KEY, array() );
+
+                if ( ! is_array( $stored ) ) {
+                        $stored = array();
+                }
+
+                return $stored;
+        }
+
+        /**
+         * Persist glossary entries.
+         *
+         * @since 0.2.0
+         *
+         * @param array $entries Entries to store.
+         *
+         * @return void
+         */
+        protected function save_entries( $entries ) {
+                update_option( self::OPTION_KEY, $entries );
+                $this->entries = $entries;
+        }
+
+        /**
+         * Retrieve glossary entries.
+         *
+         * @since 0.2.0
+         *
+         * @return array
+         */
+        public function get_entries() {
+                return $this->entries;
+        }
+
+        /**
+         * Replace glossary entries with the provided list.
+         *
+         * @since 0.2.0
+         *
+         * @param array $entries Entries to persist.
+         *
+         * @return void
+         */
+        public function replace_entries( $entries ) {
+                $sanitized = array();
+
+                foreach ( $entries as $entry ) {
+                        if ( empty( $entry['source'] ) || empty( $entry['target'] ) ) {
+                                continue;
+                        }
+
+                        $key = md5( wp_json_encode( array( $entry['source'], $entry['context'] ?? '' ) ) );
+
+                        $sanitized[ $key ] = array(
+                                'source'     => sanitize_text_field( $entry['source'] ),
+                                'target'     => sanitize_text_field( $entry['target'] ),
+                                'context'    => isset( $entry['context'] ) ? sanitize_text_field( $entry['context'] ) : '',
+                                'updated_at' => current_time( 'timestamp' ),
+                        );
+                }
+
+                $this->save_entries( $sanitized );
+        }
+
+        /**
+         * Add or update a single entry.
+         *
+         * @since 0.2.0
+         *
+         * @param string $source  Italian term.
+         * @param string $target  English translation.
+         * @param string $context Optional context label.
+         *
+         * @return void
+         */
+        public function upsert_entry( $source, $target, $context = '' ) {
+                $source  = sanitize_text_field( $source );
+                $target  = sanitize_text_field( $target );
+                $context = sanitize_text_field( $context );
+
+                if ( '' === $source || '' === $target ) {
+                        return;
+                }
+
+                $key                       = md5( wp_json_encode( array( $source, $context ) ) );
+                $this->entries[ $key ]     = array(
+                        'source'     => $source,
+                        'target'     => $target,
+                        'context'    => $context,
+                        'updated_at' => current_time( 'timestamp' ),
+                );
+                $this->save_entries( $this->entries );
+        }
+
+        /**
+         * Delete glossary entries by keys.
+         *
+         * @since 0.2.0
+         *
+         * @param array $keys Keys to remove.
+         *
+         * @return void
+         */
+        public function delete_entries( $keys ) {
+                if ( empty( $keys ) ) {
+                        return;
+                }
+
+                foreach ( $keys as $key ) {
+                        unset( $this->entries[ $key ] );
+                }
+
+                $this->save_entries( $this->entries );
+        }
+
+        /**
+         * Export glossary to JSON.
+         *
+         * @since 0.2.0
+         *
+         * @return string
+         */
+        public function export_json() {
+                return wp_json_encode( array_values( $this->entries ) );
+        }
+
+        /**
+         * Export glossary to CSV.
+         *
+         * @since 0.2.0
+         *
+         * @return string
+         */
+        public function export_csv() {
+                $rows = array();
+                $rows[] = array( 'source', 'target', 'context' );
+
+                foreach ( $this->entries as $entry ) {
+                        $rows[] = array( $entry['source'], $entry['target'], $entry['context'] );
+                }
+
+                $buffer = fopen( 'php://temp', 'w+' );
+
+                foreach ( $rows as $row ) {
+                        fputcsv( $buffer, $row );
+                }
+
+                rewind( $buffer );
+                $csv = stream_get_contents( $buffer );
+                fclose( $buffer );
+
+                return $csv;
+        }
+
+        /**
+         * Import glossary from JSON payload.
+         *
+         * @since 0.2.0
+         *
+         * @param string $json JSON payload.
+         *
+         * @return int Number of imported entries.
+         */
+        public function import_json( $json ) {
+                $decoded = json_decode( $json, true );
+
+                if ( ! is_array( $decoded ) ) {
+                        return 0;
+                }
+
+                $imported = 0;
+
+                foreach ( $decoded as $entry ) {
+                        if ( empty( $entry['source'] ) || empty( $entry['target'] ) ) {
+                                continue;
+                        }
+
+                        $this->upsert_entry( $entry['source'], $entry['target'], isset( $entry['context'] ) ? $entry['context'] : '' );
+                        $imported++;
+                }
+
+                return $imported;
+        }
+
+        /**
+         * Import glossary from CSV payload.
+         *
+         * @since 0.2.0
+         *
+         * @param string $csv CSV payload.
+         *
+         * @return int Number of imported entries.
+         */
+        public function import_csv( $csv ) {
+                $lines = explode( "\n", $csv );
+
+                if ( empty( $lines ) ) {
+                        return 0;
+                }
+
+                $imported = 0;
+                $header   = true;
+
+                foreach ( $lines as $line ) {
+                        $line = trim( $line );
+
+                        if ( '' === $line ) {
+                                continue;
+                        }
+
+                        $columns = str_getcsv( $line );
+
+                        if ( $header ) {
+                                $header = false;
+                                continue;
+                        }
+
+                        $source  = isset( $columns[0] ) ? $columns[0] : '';
+                        $target  = isset( $columns[1] ) ? $columns[1] : '';
+                        $context = isset( $columns[2] ) ? $columns[2] : '';
+
+                        if ( '' === $source || '' === $target ) {
+                                continue;
+                        }
+
+                        $this->upsert_entry( $source, $target, $context );
+                        $imported++;
+                }
+
+                return $imported;
+        }
+
+        /**
+         * Apply glossary replacements before sending text to providers.
+         *
+         * @since 0.2.0
+         *
+         * @param string              $text    Text to process.
+         * @param string              $source  Source locale code.
+         * @param string              $target  Target locale code.
+         * @param string              $context Context domain.
+         *
+         * @return string
+         */
+        public function filter_pre_translate( $text, $source, $target, $context ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+                if ( empty( $this->entries ) || ! is_string( $text ) || '' === $text ) {
+                        return $text;
+                }
+
+                $settings        = FPML_Settings::instance();
+                $case_sensitive  = $settings ? $settings->get( 'glossary_case_sensitive', false ) : false;
+                $ordered_entries = $this->get_entries_sorted();
+
+                foreach ( $ordered_entries as $entry ) {
+                        $text = $this->replace_glossary_term( $text, $entry, $case_sensitive );
+                }
+
+                return $text;
+        }
+
+        /**
+         * Restore placeholders after translation.
+         *
+         * @since 0.2.0
+         *
+         * @param string              $text    Text processed by provider.
+         * @param string              $source  Source locale code.
+         * @param string              $target  Target locale code.
+         * @param string              $context Context domain.
+         *
+         * @return string
+         */
+        public function filter_post_translate( $text, $source, $target, $context ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+                if ( ! is_string( $text ) || '' === $text ) {
+                        return $text;
+                }
+
+                return preg_replace_callback(
+                        '/\[\[FPML:([A-Za-z0-9+\/=\-_:]+)\]\]/',
+                        static function( $matches ) {
+                                $decoded = base64_decode( $matches[1], true );
+
+                                if ( false === $decoded ) {
+                                        return $matches[0];
+                                }
+
+                                return $decoded;
+                        },
+                        $text
+                );
+        }
+
+        /**
+         * Retrieve entries sorted by source length (DESC) to match longer phrases first.
+         *
+         * @since 0.2.0
+         *
+         * @return array
+         */
+        protected function get_entries_sorted() {
+                $entries = $this->entries;
+
+                uasort(
+                        $entries,
+                        static function( $a, $b ) {
+                                return mb_strlen( $b['source'], 'UTF-8' ) <=> mb_strlen( $a['source'], 'UTF-8' );
+                        }
+                );
+
+                return $entries;
+        }
+
+        /**
+         * Replace occurrences of a glossary term within the text.
+         *
+         * @since 0.2.0
+         *
+         * @param string $text           Original text.
+         * @param array  $entry          Glossary entry.
+         * @param bool   $case_sensitive Whether to match case-sensitive.
+         *
+         * @return string
+         */
+        protected function replace_glossary_term( $text, $entry, $case_sensitive ) {
+                $source = $entry['source'];
+                $target = $entry['target'];
+
+                if ( '' === $source || '' === $target ) {
+                        return $text;
+                }
+
+                $pattern = '/' . preg_quote( $source, '/' ) . '/u' . ( $case_sensitive ? '' : 'i' );
+
+                return preg_replace_callback(
+                        $pattern,
+                        static function( $matches ) use ( $target ) {
+                                $placeholder = '[[FPML:' . base64_encode( $target ) . ']]';
+                                // Preserve spacing around the match if present.
+                                if ( preg_match( '/^(\s*)(.*?)(\s*)$/u', $matches[0], $parts ) ) {
+                                        return $parts[1] . $placeholder . $parts[3];
+                                }
+
+                                return $placeholder;
+                        },
+                        $text
+                );
+        }
+}

--- a/fp-multilanguage/includes/class-language.php
+++ b/fp-multilanguage/includes/class-language.php
@@ -1,0 +1,752 @@
+<?php
+/**
+ * Language resolver and helpers.
+ *
+ * @package FP_Multilanguage
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Manage current language state, redirects and switcher helpers.
+ *
+ * @since 0.2.0
+ */
+class FPML_Language {
+    /**
+     * Cookie key for language preference.
+     */
+    const COOKIE_NAME = 'fpml_lang_pref';
+
+    /**
+     * Cookie lifetime (30 days).
+     */
+    const COOKIE_TTL = 2592000;
+
+    /**
+     * Target language slug.
+     */
+    const TARGET = 'en';
+
+    /**
+     * Source language slug.
+     */
+    const SOURCE = 'it';
+
+    /**
+     * Singleton instance.
+     *
+     * @var FPML_Language|null
+     */
+    protected static $instance = null;
+
+    /**
+     * Current language code (it|en).
+     *
+     * @var string
+     */
+    protected $current = self::SOURCE;
+
+    /**
+     * Cached settings instance.
+     *
+     * @var FPML_Settings
+     */
+    protected $settings;
+
+    /**
+     * Retrieve singleton.
+     *
+     * @since 0.2.0
+     *
+     * @return FPML_Language
+     */
+    public static function instance() {
+        if ( null === self::$instance ) {
+            self::$instance = new self();
+        }
+
+        return self::$instance;
+    }
+
+    /**
+     * Constructor.
+     */
+    protected function __construct() {
+        $this->settings = FPML_Settings::instance();
+
+        add_action( 'parse_query', array( $this, 'determine_language' ) );
+        add_action( 'template_redirect', array( $this, 'maybe_redirect_browser_language' ), 0 );
+        add_action( 'template_redirect', array( $this, 'persist_language_cookie' ), 1 );
+        add_shortcode( 'fp_lang_switcher', array( $this, 'render_switcher' ) );
+    }
+
+    /**
+     * Determine current language from query vars, request and cookies.
+     *
+     * @since 0.2.0
+     *
+     * @param WP_Query $query Current query.
+     *
+     * @return void
+     */
+    public function determine_language( $query ) {
+        if ( ! $query->is_main_query() || is_admin() ) {
+            return;
+        }
+
+        $lang = self::SOURCE;
+
+        $requested = $query->get( 'fpml_lang' );
+        if ( empty( $requested ) && isset( $_GET['lang'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+            $requested = strtolower( sanitize_text_field( wp_unslash( $_GET['lang'] ) ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+        }
+
+        if ( self::TARGET === $requested ) {
+            $lang = self::TARGET;
+        } else {
+            $path = $this->get_current_path();
+            if ( 0 === strpos( $path, '/en/' ) || '/en' === $path ) {
+                $lang = self::TARGET;
+            }
+        }
+
+        $this->current = $lang;
+        $query->set( 'fpml_lang', $lang );
+    }
+
+    /**
+     * Persist language choice in cookie for subsequent visits.
+     *
+     * @since 0.2.0
+     *
+     * @return void
+     */
+    public function persist_language_cookie() {
+        if ( is_admin() || headers_sent() ) {
+            return;
+        }
+
+        if ( ! $this->has_cookie_consent() ) {
+            return;
+        }
+
+        $cookie_value = isset( $_COOKIE[ self::COOKIE_NAME ] ) ? sanitize_text_field( wp_unslash( $_COOKIE[ self::COOKIE_NAME ] ) ) : ''; // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
+
+        if ( $cookie_value === $this->current ) {
+            return;
+        }
+
+        setcookie( // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.cookies_setcookie
+            self::COOKIE_NAME,
+            $this->current,
+            time() + self::COOKIE_TTL,
+            COOKIEPATH,
+            COOKIE_DOMAIN,
+            is_ssl(),
+            true
+        );
+
+        $_COOKIE[ self::COOKIE_NAME ] = $this->current; // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
+    }
+
+    /**
+     * Redirect first-time visitors based on browser language preference.
+     *
+     * @since 0.2.0
+     *
+     * @return void
+     */
+    public function maybe_redirect_browser_language() {
+        if ( is_admin() || wp_doing_ajax() || defined( 'REST_REQUEST' ) ) {
+            return;
+        }
+
+        if ( self::TARGET === $this->current ) {
+            return;
+        }
+
+        if ( ! $this->settings->get( 'browser_redirect', false ) ) {
+            return;
+        }
+
+        if ( ! $this->has_cookie_consent() ) {
+            return;
+        }
+
+        if ( isset( $_COOKIE[ self::COOKIE_NAME ] ) ) { // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
+            return;
+        }
+
+        $accept_language = isset( $_SERVER['HTTP_ACCEPT_LANGUAGE'] ) ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_ACCEPT_LANGUAGE'] ) ) : ''; // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.server___SERVER
+
+        if ( empty( $accept_language ) ) {
+            return;
+        }
+
+        if ( false === stripos( $accept_language, 'en' ) ) {
+            return;
+        }
+
+        $target_url = $this->get_url_for_language( self::TARGET );
+
+        if ( empty( $target_url ) || headers_sent() ) {
+            return;
+        }
+
+        wp_safe_redirect( $target_url, 302 );
+        exit;
+    }
+
+    /**
+     * Retrieve current language code.
+     *
+     * @since 0.2.0
+     *
+     * @return string
+     */
+    public function get_current_language() {
+        return $this->current;
+    }
+
+    /**
+     * Build URL for a given language keeping the current request when possible.
+     *
+     * @since 0.2.0
+     *
+     * @param string $lang Language code.
+     *
+     * @return string
+     */
+    public function get_url_for_language( $lang ) {
+        $lang = self::TARGET === strtolower( $lang ) ? self::TARGET : self::SOURCE;
+
+        $url = $this->get_contextual_url( $lang );
+
+        if ( empty( $url ) ) {
+            $url = $this->get_language_home( $lang );
+        }
+
+        $url = $this->apply_language_to_url( $url, $lang );
+
+        return esc_url_raw( $url );
+    }
+
+    /**
+     * Render the [fp_lang_switcher] shortcode.
+     *
+     * @since 0.2.0
+     *
+     * @param array $atts Shortcode attributes.
+     *
+     * @return string
+     */
+    public function render_switcher( $atts ) {
+        $atts = shortcode_atts(
+            array(
+                'style'      => 'inline',
+                'show_flags' => '0',
+            ),
+            $atts,
+            'fp_lang_switcher'
+        );
+
+        $style      = in_array( $atts['style'], array( 'inline', 'dropdown' ), true ) ? $atts['style'] : 'inline';
+        $show_flags = in_array( (string) $atts['show_flags'], array( '1', 'true', 'yes' ), true );
+        $current    = $this->get_current_language();
+
+        $languages = array(
+            self::SOURCE => array(
+                'label' => __( 'Italiano', 'fp-multilanguage' ),
+                'url'   => $this->get_url_for_language( self::SOURCE ),
+            ),
+            self::TARGET => array(
+                'label' => __( 'English', 'fp-multilanguage' ),
+                'url'   => $this->get_url_for_language( self::TARGET ),
+            ),
+        );
+
+        if ( 'dropdown' === $style ) {
+            return $this->render_dropdown_switcher( $languages, $current, $show_flags );
+        }
+
+        return $this->render_inline_switcher( $languages, $current, $show_flags );
+    }
+
+    /**
+     * Render inline language switcher.
+     *
+     * @since 0.2.0
+     *
+     * @param array  $languages Language map.
+     * @param string $current   Current language code.
+     * @param bool   $show_flags Whether to display flags.
+     *
+     * @return string
+     */
+    protected function render_inline_switcher( $languages, $current, $show_flags ) {
+        $items = array();
+
+        foreach ( $languages as $code => $language ) {
+            $classes = array( 'fpml-switcher__item' );
+
+            if ( $current === $code ) {
+                $classes[] = 'fpml-switcher__item--current';
+            }
+
+            $label = esc_html( $language['label'] );
+
+            if ( $show_flags ) {
+                $label = $this->maybe_prefix_flag( $code ) . $label;
+            }
+
+            $items[] = sprintf(
+                '<a class="%1$s" href="%2$s" rel="nofollow">%3$s</a>',
+                esc_attr( implode( ' ', $classes ) ),
+                esc_url( $language['url'] ),
+                $label
+            );
+        }
+
+        return sprintf(
+            '<div class="fpml-switcher fpml-switcher--inline">%s</div>',
+            implode( '<span class="fpml-switcher__separator"> / </span>', $items )
+        );
+    }
+
+    /**
+     * Render dropdown switcher.
+     *
+     * @since 0.2.0
+     *
+     * @param array  $languages Languages map.
+     * @param string $current   Current language code.
+     * @param bool   $show_flags Whether to display flags.
+     *
+     * @return string
+     */
+    protected function render_dropdown_switcher( $languages, $current, $show_flags ) {
+        $options = array();
+
+        foreach ( $languages as $code => $language ) {
+            $label = esc_html( $language['label'] );
+
+            if ( $show_flags ) {
+                $label = wp_kses_post( $this->maybe_prefix_flag( $code ) . $label );
+            }
+
+            $options[] = sprintf(
+                '<option value="%1$s" %3$s data-url="%2$s">%4$s</option>',
+                esc_attr( $code ),
+                esc_url( $language['url'] ),
+                selected( $current, $code, false ),
+                $label
+            );
+        }
+
+        if ( ! wp_script_is( 'fpml-switcher-dropdown', 'registered' ) ) {
+            wp_register_script( 'fpml-switcher-dropdown', '', array(), FPML_PLUGIN_VERSION, true );
+        }
+
+        wp_enqueue_script( 'fpml-switcher-dropdown' );
+
+        $script = "document.addEventListener('change',function(event){var el=event.target;if(!el.classList.contains('fpml-switcher__select')){return;}var url=el.options[el.selectedIndex].getAttribute('data-url');if(url){window.location.href=url;}});";
+        wp_add_inline_script( 'fpml-switcher-dropdown', $script );
+
+        return sprintf(
+            '<div class="fpml-switcher fpml-switcher--dropdown"><select class="fpml-switcher__select">%s</select></div>',
+            implode( '', $options )
+        );
+    }
+
+    /**
+     * Maybe prefix label with flag span.
+     *
+     * @since 0.2.0
+     *
+     * @param string $code Language code.
+     *
+     * @return string
+     */
+    protected function maybe_prefix_flag( $code ) {
+        $flags = array(
+            self::SOURCE => '🇮🇹',
+            self::TARGET => '🇺🇸',
+        );
+
+        if ( ! isset( $flags[ $code ] ) ) {
+            return '';
+        }
+
+        return sprintf( '<span class="fpml-switcher__flag" aria-hidden="true">%s</span> ', esc_html( $flags[ $code ] ) );
+    }
+
+    /**
+     * Obtain the current full URL.
+     *
+     * @since 0.2.0
+     *
+     * @return string
+     */
+    protected function get_current_url() {
+        $scheme = is_ssl() ? 'https' : 'http';
+
+        $host = isset( $_SERVER['HTTP_HOST'] ) ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_HOST'] ) ) : ''; // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.server___SERVER
+        $uri  = isset( $_SERVER['REQUEST_URI'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : ''; // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.server___SERVER
+
+        return esc_url_raw( $scheme . '://' . $host . $uri );
+    }
+
+    /**
+     * Get current request path.
+     *
+     * @since 0.2.0
+     *
+     * @return string
+     */
+    protected function get_current_path() {
+        $current = wp_parse_url( $this->get_current_url(), PHP_URL_PATH );
+
+        if ( ! is_string( $current ) ) {
+            return '/';
+        }
+
+        if ( '' === $current ) {
+            return '/';
+        }
+
+        if ( '/' !== substr( $current, 0, 1 ) ) {
+            $current = '/' . $current;
+        }
+
+        return untrailingslashit( $current ) . '/';
+    }
+
+    /**
+     * Strip language segment from a path.
+     *
+     * @since 0.2.0
+     *
+     * @param string $path Current path.
+     *
+     * @return string
+     */
+    protected function strip_language_segment( $path ) {
+        $path = '/' === $path ? '/' : untrailingslashit( $path ) . '/';
+
+        if ( 0 === strpos( $path, '/en/' ) ) {
+            $path = substr( $path, 3 );
+        } elseif ( '/en/' === $path ) {
+            $path = '/';
+        }
+
+        return $path;
+    }
+
+    /**
+     * Derive the contextual URL for the requested language.
+     *
+     * @since 0.2.0
+     *
+     * @param string $lang Target language code.
+     *
+     * @return string
+     */
+    protected function get_contextual_url( $lang ) {
+        if ( is_singular() ) {
+            $object = get_queried_object();
+
+            if ( $object instanceof WP_Post ) {
+                $url = $this->get_post_translation_url( $object, $lang );
+
+                if ( ! empty( $url ) ) {
+                    return $url;
+                }
+            }
+        }
+
+        if ( is_tax() || is_category() || is_tag() ) {
+            $term = get_queried_object();
+
+            if ( $term instanceof WP_Term ) {
+                $url = $this->get_term_translation_url( $term, $lang );
+
+                if ( ! empty( $url ) ) {
+                    return $url;
+                }
+            }
+        }
+
+        if ( is_post_type_archive() ) {
+            $post_type = get_query_var( 'post_type' );
+
+            if ( is_array( $post_type ) ) {
+                $post_type = reset( $post_type );
+            }
+
+            if ( is_string( $post_type ) && '' !== $post_type ) {
+                $link = get_post_type_archive_link( $post_type );
+
+                if ( $link ) {
+                    return $link;
+                }
+            }
+
+            return $this->get_current_url();
+        }
+
+        if ( is_search() || is_author() || is_date() ) {
+            return $this->get_current_url();
+        }
+
+        return '';
+    }
+
+    /**
+     * Retrieve the translated permalink for a post.
+     *
+     * @since 0.2.0
+     *
+     * @param WP_Post $post Post object.
+     * @param string  $lang Language code.
+     *
+     * @return string
+     */
+    protected function get_post_translation_url( WP_Post $post, $lang ) {
+        if ( self::TARGET === $lang ) {
+            if ( get_post_meta( $post->ID, '_fpml_is_translation', true ) ) {
+                return get_permalink( $post );
+            }
+
+            $target_id = (int) get_post_meta( $post->ID, '_fpml_pair_id', true );
+
+            if ( $target_id > 0 ) {
+                $target = get_post( $target_id );
+
+                if ( $target instanceof WP_Post && in_array( $target->post_status, array( 'publish', 'inherit' ), true ) ) {
+                    return get_permalink( $target );
+                }
+            }
+
+            return '';
+        }
+
+        if ( get_post_meta( $post->ID, '_fpml_is_translation', true ) ) {
+            $source_id = (int) get_post_meta( $post->ID, '_fpml_pair_source_id', true );
+
+            if ( $source_id > 0 ) {
+                $source = get_post( $source_id );
+
+                if ( $source instanceof WP_Post && in_array( $source->post_status, array( 'publish', 'inherit' ), true ) ) {
+                    return get_permalink( $source );
+                }
+            }
+
+            return '';
+        }
+
+        return get_permalink( $post );
+    }
+
+    /**
+     * Retrieve the translated permalink for a taxonomy term.
+     *
+     * @since 0.2.0
+     *
+     * @param WP_Term $term Term object.
+     * @param string  $lang Language code.
+     *
+     * @return string
+     */
+    protected function get_term_translation_url( WP_Term $term, $lang ) {
+        if ( self::TARGET === $lang ) {
+            if ( get_term_meta( $term->term_id, '_fpml_is_translation', true ) ) {
+                $link = get_term_link( $term );
+
+                return is_wp_error( $link ) ? '' : $link;
+            }
+
+            $target_id = (int) get_term_meta( $term->term_id, '_fpml_pair_id', true );
+
+            if ( $target_id > 0 ) {
+                $target = get_term( $target_id, $term->taxonomy );
+
+                if ( $target instanceof WP_Term ) {
+                    $link = get_term_link( $target );
+
+                    return is_wp_error( $link ) ? '' : $link;
+                }
+            }
+
+            return '';
+        }
+
+        if ( get_term_meta( $term->term_id, '_fpml_is_translation', true ) ) {
+            $source_id = (int) get_term_meta( $term->term_id, '_fpml_pair_source_id', true );
+
+            if ( $source_id > 0 ) {
+                $source = get_term( $source_id, $term->taxonomy );
+
+                if ( $source instanceof WP_Term ) {
+                    $link = get_term_link( $source );
+
+                    return is_wp_error( $link ) ? '' : $link;
+                }
+            }
+
+            return '';
+        }
+
+        $link = get_term_link( $term );
+
+        return is_wp_error( $link ) ? '' : $link;
+    }
+
+    /**
+     * Return the language-specific home URL baseline.
+     *
+     * @since 0.2.0
+     *
+     * @param string $lang Language code.
+     *
+     * @return string
+     */
+    protected function get_language_home( $lang ) {
+        unset( $lang );
+
+        return home_url( '/' );
+    }
+
+    /**
+     * Apply routing rules to a base URL according to language.
+     *
+     * @since 0.2.0
+     *
+     * @param string $url  Base URL.
+     * @param string $lang Language code.
+     *
+     * @return string
+     */
+    protected function apply_language_to_url( $url, $lang ) {
+        $routing = $this->settings->get( 'routing_mode', 'segment' );
+
+        if ( 'segment' !== $routing ) {
+            $url = remove_query_arg( 'lang', $url );
+
+            if ( self::TARGET === $lang ) {
+                $url = add_query_arg( 'lang', self::TARGET, $url );
+            }
+
+            return $url;
+        }
+
+        $parsed = wp_parse_url( $url );
+
+        if ( false === $parsed ) {
+            return $url;
+        }
+
+        $path = isset( $parsed['path'] ) ? $parsed['path'] : '/';
+        $path = $this->normalize_path( $path );
+
+        if ( self::TARGET === $lang ) {
+            $path = 'en' . ( '' !== $path ? '/' . $path : '' );
+        }
+
+        $path = trim( $path, '/' );
+
+        if ( '' === $path ) {
+            $target = home_url( '/' );
+        } else {
+            $target = home_url( trailingslashit( $path ) );
+        }
+
+        if ( ! empty( $parsed['query'] ) ) {
+            $target = rtrim( $target, '?' );
+            $target .= '?' . $parsed['query'];
+        }
+
+        if ( ! empty( $parsed['fragment'] ) ) {
+            $fragment = sanitize_text_field( $parsed['fragment'] );
+
+            if ( '' !== $fragment ) {
+                $target .= '#' . rawurlencode( $fragment );
+            }
+        }
+
+        return $target;
+    }
+
+    /**
+     * Normalize an URL path stripping the language segment.
+     *
+     * @since 0.2.0
+     *
+     * @param string $path Path to normalize.
+     *
+     * @return string
+     */
+    protected function normalize_path( $path ) {
+        if ( ! is_string( $path ) || '' === $path ) {
+            return '';
+        }
+
+        if ( '/' !== substr( $path, 0, 1 ) ) {
+            $path = '/' . $path;
+        }
+
+        $path = $this->strip_language_segment( $path );
+
+        return trim( $path, '/' );
+    }
+
+    /**
+     * Determine whether user consent is available for redirect/cookies.
+     *
+     * @since 0.2.0
+     *
+     * @return bool
+     */
+    protected function has_cookie_consent() {
+        if ( ! $this->settings->get( 'browser_redirect_requires_consent', false ) ) {
+            return true;
+        }
+
+        $cookie_name = $this->settings->get( 'browser_redirect_consent_cookie', '' );
+
+        if ( '' === $cookie_name ) {
+            return false;
+        }
+
+        if ( ! isset( $_COOKIE[ $cookie_name ] ) ) { // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
+            return false;
+        }
+
+        $raw_value = wp_unslash( $_COOKIE[ $cookie_name ] ); // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
+        $value     = strtolower( trim( wp_check_invalid_utf8( $raw_value ) ) );
+
+        if ( '' === $value ) {
+            return false;
+        }
+
+        $negative = array( '0', 'false', 'deny', 'denied', 'reject', 'no' );
+
+        if ( in_array( $value, $negative, true ) ) {
+            return false;
+        }
+
+        /**
+         * Filter the detection of cookie consent value.
+         *
+         * @since 0.2.0
+         *
+         * @param bool   $has_consent Whether consent is granted.
+         * @param string $cookie_name Cookie name.
+         * @param string $raw_value   Raw cookie value.
+         */
+        return (bool) apply_filters( 'fpml_has_cookie_consent', true, $cookie_name, $raw_value );
+    }
+}
+

--- a/fp-multilanguage/includes/class-logger.php
+++ b/fp-multilanguage/includes/class-logger.php
@@ -1,0 +1,307 @@
+<?php
+/**
+ * Lightweight logger that stores events in an option.
+ *
+ * @package FP_Multilanguage
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+        exit;
+}
+
+/**
+ * Persist log entries without writing files.
+ *
+ * @since 0.2.0
+ */
+class FPML_Logger {
+        /**
+         * Option key for log storage.
+         *
+         * @var string
+         */
+        protected $option_key = 'fpml_logs';
+
+        /**
+         * Max entries retained.
+         *
+         * @var int
+         */
+        protected $max_entries = 200;
+
+        /**
+         * Singleton instance.
+         *
+         * @var FPML_Logger|null
+         */
+        protected static $instance = null;
+
+        /**
+         * Retrieve singleton instance.
+         *
+         * @since 0.2.0
+         *
+         * @return FPML_Logger
+         */
+        public static function instance() {
+                if ( null === self::$instance ) {
+                        self::$instance = new self();
+                }
+
+                return self::$instance;
+        }
+
+        /**
+         * Constructor.
+         */
+        protected function __construct() {
+                $this->max_entries = (int) apply_filters( 'fpml_logger_max_entries', $this->max_entries );
+        }
+
+        /**
+         * Write a log entry.
+         *
+         * @since 0.2.0
+         *
+         * @param string $level   info|warn|error.
+         * @param string $message Message to log.
+         * @param array  $context Additional context data.
+         *
+         * @return void
+         */
+        public function log( $level, $message, $context = array() ) {
+                $level   = $this->normalize_level( $level );
+                $message = $this->sanitize_text( $message );
+                $context = $this->sanitize_context( $context );
+
+                $entry = array(
+                        'timestamp' => current_time( 'mysql', true ),
+                        'level'     => $level,
+                        'message'   => $message,
+                        'context'   => $context,
+                );
+
+                $logs = get_option( $this->option_key, array() );
+                $logs = is_array( $logs ) ? $logs : array();
+
+                array_unshift( $logs, $entry );
+
+                if ( count( $logs ) > $this->max_entries ) {
+                        $logs = array_slice( $logs, 0, $this->max_entries );
+                }
+
+                update_option( $this->option_key, $logs, false );
+        }
+
+        /**
+         * Retrieve logs.
+         *
+         * @since 0.2.0
+         *
+         * @param int $limit Maximum entries to return.
+         *
+         * @return array
+         */
+        public function get_logs( $limit = 50 ) {
+                $limit = max( 1, absint( $limit ) );
+                $logs  = get_option( $this->option_key, array() );
+
+                if ( ! is_array( $logs ) ) {
+                        return array();
+                }
+
+                return array_slice( $logs, 0, $limit );
+        }
+
+        /**
+         * Remove all stored logs.
+         *
+         * @since 0.2.0
+         *
+         * @return void
+         */
+        public function clear() {
+                delete_option( $this->option_key );
+        }
+
+        /**
+         * Import log entries keeping sanitation and anonymization rules.
+         *
+         * @since 0.2.0
+         *
+         * @param array $entries Entries to import.
+         *
+         * @return int
+         */
+        public function import_logs( $entries ) {
+                if ( empty( $entries ) || ! is_array( $entries ) ) {
+                        return 0;
+                }
+
+                $stored = get_option( $this->option_key, array() );
+                $stored = is_array( $stored ) ? $stored : array();
+                $imported = 0;
+
+                foreach ( $entries as $entry ) {
+                        if ( empty( $entry['message'] ) ) {
+                                continue;
+                        }
+
+                        $record = array(
+                                'timestamp' => isset( $entry['timestamp'] ) ? sanitize_text_field( $entry['timestamp'] ) : current_time( 'mysql', true ),
+                                'level'     => $this->normalize_level( isset( $entry['level'] ) ? $entry['level'] : 'info' ),
+                                'message'   => $this->sanitize_text( $entry['message'] ),
+                                'context'   => $this->sanitize_context( isset( $entry['context'] ) ? $entry['context'] : array() ),
+                        );
+
+                        array_unshift( $stored, $record );
+                        $imported++;
+                }
+
+                if ( $imported > 0 ) {
+                        if ( count( $stored ) > $this->max_entries ) {
+                                $stored = array_slice( $stored, 0, $this->max_entries );
+                        }
+
+                        update_option( $this->option_key, $stored, false );
+                }
+
+                return $imported;
+        }
+
+        /**
+         * Count logs grouped by level.
+         *
+         * @since 0.2.0
+         *
+         * @return array
+         */
+        public function get_stats() {
+                $logs  = get_option( $this->option_key, array() );
+                $stats = array(
+                        'info'  => 0,
+                        'warn'  => 0,
+                        'error' => 0,
+                );
+
+                if ( ! is_array( $logs ) ) {
+                        return $stats;
+                }
+
+                foreach ( $logs as $log ) {
+                        if ( empty( $log['level'] ) ) {
+                                continue;
+                        }
+
+                        $level = $this->normalize_level( $log['level'] );
+
+                        if ( isset( $stats[ $level ] ) ) {
+                                $stats[ $level ]++;
+                        }
+                }
+
+                return $stats;
+        }
+
+        /**
+         * Normalize log level.
+         *
+         * @since 0.2.0
+         *
+         * @param string $level Incoming level.
+         *
+         * @return string
+         */
+        protected function normalize_level( $level ) {
+                $level = strtolower( sanitize_text_field( $level ) );
+
+                if ( ! in_array( $level, array( 'info', 'warn', 'error' ), true ) ) {
+                        $level = 'info';
+                }
+
+                return $level;
+        }
+
+        /**
+         * Sanitize log message and optionally anonymize sensitive data.
+         *
+         * @since 0.2.0
+         *
+         * @param string $text Raw message.
+         *
+         * @return string
+         */
+        protected function sanitize_text( $text ) {
+                $text = sanitize_textarea_field( $text );
+
+                if ( $this->should_anonymize() ) {
+                        $text = $this->anonymize_text( $text );
+                }
+
+                return $text;
+        }
+
+        /**
+         * Sanitize contextual data.
+         *
+         * @since 0.2.0
+         *
+         * @param array $context Raw context.
+         *
+         * @return array
+         */
+        protected function sanitize_context( $context ) {
+                if ( empty( $context ) ) {
+                        return array();
+                }
+
+                $clean = array();
+
+                foreach ( (array) $context as $key => $value ) {
+                        $key = sanitize_key( $key );
+
+                        if ( is_scalar( $value ) ) {
+                                $value = sanitize_textarea_field( (string) $value );
+                        } else {
+                                $value = wp_json_encode( $value );
+                        }
+
+                        if ( $this->should_anonymize() ) {
+                                $value = $this->anonymize_text( $value );
+                        }
+
+                        $clean[ $key ] = $value;
+                }
+
+                return $clean;
+        }
+
+        /**
+         * Check if anonymization is enabled.
+         *
+         * @since 0.2.0
+         *
+         * @return bool
+         */
+        protected function should_anonymize() {
+                $settings = FPML_Settings::instance();
+
+                return (bool) $settings->get( 'anonymize_logs', false );
+        }
+
+        /**
+         * Replace obvious personal data markers.
+         *
+         * @since 0.2.0
+         *
+         * @param string $text Text to scrub.
+         *
+         * @return string
+         */
+        protected function anonymize_text( $text ) {
+                $text = preg_replace( '/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/i', '[redacted-email]', $text );
+                $text = preg_replace( '/\b\d{4,}\b/', '[redacted-number]', $text );
+
+                return $text;
+        }
+}

--- a/fp-multilanguage/includes/class-menu-sync.php
+++ b/fp-multilanguage/includes/class-menu-sync.php
@@ -1,0 +1,388 @@
+<?php
+/**
+ * Menu synchronization utilities.
+ *
+ * @package FP_Multilanguage
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+        exit;
+}
+
+/**
+ * Keep English menus in sync with Italian sources.
+ *
+ * @since 0.2.0
+ */
+class FPML_Menu_Sync {
+        /**
+         * Singleton instance.
+         *
+         * @var FPML_Menu_Sync|null
+         */
+        protected static $instance = null;
+
+        /**
+         * Queue handler.
+         *
+         * @var FPML_Queue
+         */
+        protected $queue;
+
+        /**
+         * Logger helper.
+         *
+         * @var FPML_Logger
+         */
+        protected $logger;
+
+        /**
+         * Whether the synchronizer is currently processing.
+         *
+         * @var bool
+         */
+        protected $is_syncing = false;
+
+        /**
+         * Retrieve singleton instance.
+         *
+         * @since 0.2.0
+         *
+         * @return FPML_Menu_Sync
+         */
+        public static function instance() {
+                if ( null === self::$instance ) {
+                        self::$instance = new self();
+                }
+
+                return self::$instance;
+        }
+
+        /**
+         * Constructor.
+         */
+        protected function __construct() {
+                $this->queue  = FPML_Queue::instance();
+                $this->logger = FPML_Logger::instance();
+
+                add_action( 'wp_update_nav_menu', array( $this, 'handle_menu_update' ), 10, 2 );
+        }
+
+        /**
+         * Sync menu structure whenever the Italian menu is saved.
+         *
+         * @since 0.2.0
+         *
+         * @param int   $menu_id   Menu term ID.
+         * @param array $menu_data Menu data payload.
+         *
+         * @return void
+         */
+        public function handle_menu_update( $menu_id, $menu_data ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+                if ( $this->is_syncing ) {
+                        return;
+                }
+
+                $menu = wp_get_nav_menu_object( $menu_id );
+
+                if ( ! $menu || is_wp_error( $menu ) ) {
+                        return;
+                }
+
+                if ( get_term_meta( $menu_id, '_fpml_is_translation', true ) ) {
+                        return;
+                }
+
+                $this->is_syncing = true;
+
+                try {
+                        $target_menu = $this->ensure_target_menu( $menu );
+
+                        if ( ! $target_menu ) {
+                                return;
+                        }
+
+                        $this->sync_menu_items( $menu, $target_menu );
+                } finally {
+                        $this->is_syncing = false;
+                }
+        }
+
+        /**
+         * Ensure the English counterpart menu exists.
+         *
+         * @since 0.2.0
+         *
+         * @param WP_Term $menu Source menu term.
+         *
+         * @return WP_Term|false
+         */
+        protected function ensure_target_menu( $menu ) {
+                $target_id = (int) get_term_meta( $menu->term_id, '_fpml_pair_id', true );
+
+                if ( $target_id ) {
+                        $target = wp_get_nav_menu_object( $target_id );
+
+                        if ( $target && ! is_wp_error( $target ) ) {
+                                return $target;
+                        }
+                }
+
+                $name = $menu->name . ' EN';
+                $slug = sanitize_title( $menu->slug . '-en' );
+
+                $result = wp_create_nav_menu(
+                        $name,
+                        array(
+                                'slug' => $slug,
+                        )
+                );
+
+                if ( is_wp_error( $result ) ) {
+                        if ( 'menu_exists' === $result->get_error_code() ) {
+                                $existing = wp_get_nav_menu_object( $slug );
+
+                                if ( $existing && ! is_wp_error( $existing ) ) {
+                                        $target_id = (int) $existing->term_id;
+
+                                        update_term_meta( $menu->term_id, '_fpml_pair_id', $target_id );
+                                        update_term_meta( $target_id, '_fpml_pair_source_id', $menu->term_id );
+                                        update_term_meta( $target_id, '_fpml_is_translation', 1 );
+
+                                        return $existing;
+                                }
+                        }
+
+                        $this->logger->log(
+                                'error',
+                                sprintf( 'Impossibile creare il menu inglese per %s: %s', $menu->name, $result->get_error_message() ),
+                                array(
+                                        'menu_id' => $menu->term_id,
+                                )
+                        );
+
+                        return false;
+                }
+
+                $target_id = (int) $result;
+
+                update_term_meta( $menu->term_id, '_fpml_pair_id', $target_id );
+                update_term_meta( $target_id, '_fpml_pair_source_id', $menu->term_id );
+                update_term_meta( $target_id, '_fpml_is_translation', 1 );
+
+                $target = wp_get_nav_menu_object( $target_id );
+
+                if ( ! $target || is_wp_error( $target ) ) {
+                        return false;
+                }
+
+                return $target;
+        }
+
+        /**
+         * Synchronize menu items between Italian and English menus.
+         *
+         * @since 0.2.0
+         *
+         * @param WP_Term $source_menu Source menu term.
+         * @param WP_Term $target_menu Target menu term.
+         *
+         * @return void
+         */
+        protected function sync_menu_items( $source_menu, $target_menu ) {
+                $source_items = wp_get_nav_menu_items( $source_menu->term_id, array( 'post_status' => 'any' ) );
+                $target_items = wp_get_nav_menu_items( $target_menu->term_id, array( 'post_status' => 'any' ) );
+
+                $target_map = array();
+
+                foreach ( (array) $target_items as $item ) {
+                        $source_id = (int) get_post_meta( $item->ID, '_fpml_pair_source_id', true );
+
+                        if ( $source_id ) {
+                                $target_map[ $source_id ] = (int) $item->ID;
+                        }
+                }
+
+                usort( $source_items, function ( $a, $b ) {
+                        $order_a = isset( $a->menu_order ) ? (int) $a->menu_order : 0;
+                        $order_b = isset( $b->menu_order ) ? (int) $b->menu_order : 0;
+
+                        if ( $order_a === $order_b ) {
+                                return 0;
+                        }
+
+                        return ( $order_a < $order_b ) ? -1 : 1;
+                } );
+
+                $processed = array();
+                $relation  = array();
+
+                foreach ( (array) $source_items as $item ) {
+                        $parent_id        = isset( $item->menu_item_parent ) ? (int) $item->menu_item_parent : 0;
+                        $target_parent_id = $parent_id && isset( $relation[ $parent_id ] ) ? $relation[ $parent_id ] : 0;
+                        $existing_id      = isset( $target_map[ $item->ID ] ) ? $target_map[ $item->ID ] : 0;
+
+                        $args = $this->build_menu_item_args( $item, $target_parent_id );
+
+                        $new_id = wp_update_nav_menu_item( $target_menu->term_id, $existing_id, $args );
+
+                        if ( is_wp_error( $new_id ) || ! $new_id ) {
+                                $this->logger->log(
+                                        'error',
+                                        sprintf( 'Impossibile sincronizzare la voce di menu #%d: %s', $item->ID, is_wp_error( $new_id ) ? $new_id->get_error_message() : 'errore sconosciuto' ),
+                                        array(
+                                                'menu_id'    => $source_menu->term_id,
+                                                'item_id'    => $item->ID,
+                                                'target_id'  => $existing_id,
+                                        )
+                                );
+
+                                continue;
+                        }
+
+                        $relation[ $item->ID ] = (int) $new_id;
+                        $processed[]           = (int) $new_id;
+
+                        update_post_meta( $item->ID, '_fpml_pair_id', $new_id );
+                        update_post_meta( $new_id, '_fpml_pair_source_id', $item->ID );
+                        update_post_meta( $new_id, '_fpml_is_translation', 1 );
+
+                        $this->update_menu_status_flag( $new_id, 'title', 'needs_update' );
+
+                        if ( ! empty( $item->title ) ) {
+                                $this->queue->enqueue( 'menu', $item->ID, 'title', md5( (string) $item->title ) );
+                        }
+                }
+
+                foreach ( (array) $target_items as $item ) {
+                        if ( in_array( (int) $item->ID, $processed, true ) ) {
+                                continue;
+                        }
+
+                        $source_id = (int) get_post_meta( $item->ID, '_fpml_pair_source_id', true );
+
+                        if ( $source_id && isset( $relation[ $source_id ] ) ) {
+                                continue;
+                        }
+
+                        wp_delete_post( $item->ID, true );
+                }
+        }
+
+        /**
+         * Build arguments for wp_update_nav_menu_item.
+         *
+         * @since 0.2.0
+         *
+         * @param WP_Post $item            Menu item.
+         * @param int     $target_parent_id Target parent ID.
+         *
+         * @return array
+         */
+        protected function build_menu_item_args( $item, $target_parent_id ) {
+                $classes = array();
+
+                if ( isset( $item->classes ) && is_array( $item->classes ) ) {
+                        $classes = array_filter( array_map( 'sanitize_html_class', $item->classes ) );
+                }
+
+                $args = array(
+                        'menu-item-title'      => $item->title,
+                        'menu-item-status'     => $item->post_status,
+                        'menu-item-position'   => isset( $item->menu_order ) ? (int) $item->menu_order : 0,
+                        'menu-item-parent-id'  => $target_parent_id,
+                        'menu-item-attr-title' => isset( $item->attr_title ) ? $item->attr_title : '',
+                        'menu-item-target'     => isset( $item->target ) ? $item->target : '',
+                        'menu-item-classes'    => implode( ' ', $classes ),
+                        'menu-item-xfn'        => isset( $item->xfn ) ? $item->xfn : '',
+                        'menu-item-description'=> isset( $item->description ) ? $item->description : '',
+                );
+
+                if ( 'custom' === $item->type ) {
+                        $args['menu-item-type']        = 'custom';
+                        $args['menu-item-url']         = isset( $item->url ) ? $item->url : '';
+                        $args['menu-item-object']      = 'custom';
+                        $args['menu-item-object-id']   = 0;
+                } elseif ( 'taxonomy' === $item->type ) {
+                        $target_term = (int) get_term_meta( $item->object_id, '_fpml_pair_id', true );
+                        $args['menu-item-type']        = 'taxonomy';
+                        $args['menu-item-object']      = $item->object;
+                        $args['menu-item-object-id']   = $target_term ? $target_term : $item->object_id;
+                        $args['menu-item-url']         = '';
+                } elseif ( 'post_type' === $item->type ) {
+                        $target_post = (int) get_post_meta( $item->object_id, '_fpml_pair_id', true );
+                        $args['menu-item-type']        = 'post_type';
+                        $args['menu-item-object']      = $item->object;
+                        $args['menu-item-object-id']   = $target_post ? $target_post : $item->object_id;
+                        $args['menu-item-url']         = '';
+                } else {
+                        $args['menu-item-type']      = $item->type;
+                        $args['menu-item-object']    = $item->object;
+                        $args['menu-item-object-id'] = $item->object_id;
+                        $args['menu-item-url']       = isset( $item->url ) ? $item->url : '';
+                }
+
+                return $args;
+        }
+
+        /**
+         * Update translation status meta for menu items.
+         *
+         * @since 0.2.0
+         *
+         * @param int    $item_id Menu item ID.
+         * @param string $field   Field identifier.
+         * @param string $status  Status slug.
+         *
+         * @return void
+         */
+        protected function update_menu_status_flag( $item_id, $field, $status ) {
+                $meta_key = '_fpml_status_' . sanitize_key( str_replace( ':', '_', $field ) );
+
+                update_post_meta( $item_id, $meta_key, sanitize_key( $status ) );
+        }
+
+        /**
+         * Force synchronization of every registered menu.
+         *
+         * @since 0.2.0
+         *
+         * @return int Number of menus processed.
+         */
+        public function resync_all() {
+                $menus = wp_get_nav_menus( array( 'hide_empty' => false ) );
+
+                if ( empty( $menus ) ) {
+                        return 0;
+                }
+
+                $processed = 0;
+
+                foreach ( $menus as $menu ) {
+                        if ( ! $menu instanceof WP_Term ) {
+                                continue;
+                        }
+
+                        if ( get_term_meta( $menu->term_id, '_fpml_is_translation', true ) ) {
+                                continue;
+                        }
+
+                        $this->is_syncing = true;
+
+                        try {
+                                $target_menu = $this->ensure_target_menu( $menu );
+
+                                if ( ! $target_menu ) {
+                                        continue;
+                                }
+
+                                $this->sync_menu_items( $menu, $target_menu );
+                                $processed++;
+                        } finally {
+                                $this->is_syncing = false;
+                        }
+                }
+
+                return $processed;
+        }
+}

--- a/fp-multilanguage/includes/class-plugin.php
+++ b/fp-multilanguage/includes/class-plugin.php
@@ -1,0 +1,1099 @@
+<?php
+/**
+ * Core plugin bootstrap.
+ *
+ * @package FP_Multilanguage
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Main plugin class.
+ *
+ * @since 0.2.0
+ */
+class FPML_Plugin {
+        /**
+         * Singleton instance.
+         *
+         * @var FPML_Plugin|null
+         */
+        protected static $instance = null;
+
+        /**
+         * Cached settings instance.
+         *
+         * @var FPML_Settings
+         */
+        protected $settings;
+
+        /**
+         * Cached queue handler.
+         *
+         * @var FPML_Queue
+         */
+        protected $queue;
+
+        /**
+         * Cached logger.
+         *
+         * @var FPML_Logger
+         */
+        protected $logger;
+
+        /**
+         * Flag to avoid recursion while creating translations.
+         *
+         * @var bool
+         */
+        protected $creating_translation = false;
+
+        /**
+         * Flag to avoid recursion while creating term translations.
+         *
+         * @var bool
+         */
+        protected $creating_term_translation = false;
+
+        /**
+         * Whether the plugin is running in assisted mode (WPML/Polylang active).
+         *
+         * @var bool
+         */
+        protected $assisted_mode = false;
+
+        /**
+         * Identifier of the multilingual plugin triggering assisted mode.
+         *
+         * @var string
+         */
+        protected $assisted_reason = '';
+
+        /**
+         * Plugin constructor.
+         */
+        protected function __construct() {
+                $this->detect_assisted_mode();
+
+                $this->settings = FPML_Settings::instance();
+                $this->queue    = FPML_Queue::instance();
+                $this->logger   = FPML_Logger::instance();
+
+                $this->define_hooks();
+        }
+
+	/**
+	 * Retrieve singleton instance.
+	 *
+	 * @since 0.2.0
+	 *
+	 * @return FPML_Plugin
+	 */
+	public static function instance() {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Plugin activation callback.
+	 *
+	 * @since 0.2.0
+	 *
+	 * @return void
+	 */
+        public static function activate() {
+                $reason = self::detect_external_multilingual();
+
+                if ( ! $reason ) {
+                        FPML_Rewrites::instance()->register_rewrites();
+                }
+
+                FPML_Queue::instance()->install();
+                flush_rewrite_rules();
+        }
+
+	/**
+	 * Plugin deactivation callback.
+	 *
+	 * @since 0.2.0
+	 *
+	 * @return void
+	 */
+        public static function deactivate() {
+                flush_rewrite_rules();
+        }
+
+        /**
+         * Detect active multilingual plugins that require assisted mode.
+         *
+         * @since 0.2.0
+         *
+         * @return string Empty string when no external plugin is detected, otherwise the identifier.
+         */
+        protected static function detect_external_multilingual() {
+                if ( defined( 'ICL_SITEPRESS_VERSION' ) || function_exists( 'icl_object_id' ) ) {
+                        return 'wpml';
+                }
+
+                if ( defined( 'POLYLANG_VERSION' ) || function_exists( 'pll_current_language' ) ) {
+                        return 'polylang';
+                }
+
+                return '';
+        }
+
+        /**
+         * Detect whether the plugin should operate in assisted mode.
+         *
+         * @since 0.2.0
+         *
+         * @return void
+         */
+        protected function detect_assisted_mode() {
+                $reason = self::detect_external_multilingual();
+
+                if ( $reason ) {
+                        $this->assisted_mode   = true;
+                        $this->assisted_reason = $reason;
+                }
+        }
+
+        /**
+         * Check if assisted mode is active.
+         *
+         * @since 0.2.0
+         *
+         * @return bool
+         */
+        public function is_assisted_mode() {
+                return (bool) $this->assisted_mode;
+        }
+
+        /**
+         * Retrieve the assisted mode reason identifier.
+         *
+         * @since 0.2.0
+         *
+         * @return string
+         */
+        public function get_assisted_reason() {
+                return $this->assisted_reason;
+        }
+
+        /**
+         * Get a human readable label for the assisted mode reason.
+         *
+         * @since 0.2.0
+         *
+         * @return string
+         */
+        public function get_assisted_reason_label() {
+                switch ( $this->assisted_reason ) {
+                        case 'wpml':
+                                return 'WPML';
+                        case 'polylang':
+                                return 'Polylang';
+                        default:
+                                return '';
+                }
+        }
+
+	/**
+	 * Define hooks and bootstrap classes.
+	 *
+	 * @since 0.2.0
+	 *
+	 * @return void
+	 */
+        protected function define_hooks() {
+                load_plugin_textdomain( 'fp-multilanguage', false, dirname( plugin_basename( FPML_PLUGIN_FILE ) ) . '/languages' );
+
+                FPML_Settings::instance();
+                FPML_Logger::instance();
+                FPML_Glossary::instance();
+                FPML_Strings_Override::instance();
+                FPML_Strings_Scanner::instance();
+                FPML_Export_Import::instance();
+
+                if ( ! $this->assisted_mode ) {
+                        FPML_Rewrites::instance();
+                        FPML_Language::instance();
+                        FPML_Content_Diff::instance();
+                        FPML_Processor::instance();
+                        FPML_Menu_Sync::instance();
+                        FPML_SEO::instance();
+                }
+
+                if ( class_exists( 'FPML_REST_Admin' ) ) {
+                        FPML_REST_Admin::instance();
+                }
+
+                if ( is_admin() ) {
+                        new FPML_Admin();
+                }
+
+                if ( ! $this->assisted_mode ) {
+                        add_action( 'save_post', array( $this, 'handle_save_post' ), 20, 3 );
+                        add_action( 'created_term', array( $this, 'handle_created_term' ), 10, 3 );
+                        add_action( 'edited_term', array( $this, 'handle_edited_term' ), 10, 3 );
+                }
+        }
+
+        /**
+         * Handle post save events to ensure translations and enqueue jobs.
+         *
+         * @since 0.2.0
+         *
+         * @param int     $post_id Post ID.
+         * @param WP_Post $post    Post object.
+         * @param bool    $update  Whether this is an existing post being updated.
+         *
+         * @return void
+         */
+        public function handle_save_post( $post_id, $post, $update ) {
+                if ( $this->is_assisted_mode() ) {
+                        return;
+                }
+
+                if ( $this->creating_translation ) {
+                        return;
+                }
+
+                if ( ! $post instanceof WP_Post ) {
+                        return;
+                }
+
+                if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+                        return;
+                }
+
+                if ( wp_is_post_autosave( $post_id ) || wp_is_post_revision( $post_id ) ) {
+                        return;
+                }
+
+                if ( 'auto-draft' === $post->post_status ) {
+                        return;
+                }
+
+                if ( get_post_meta( $post_id, '_fpml_is_translation', true ) ) {
+                        return;
+                }
+
+                $post_types = $this->get_translatable_post_types();
+
+                if ( empty( $post_types ) || ! in_array( $post->post_type, $post_types, true ) ) {
+                        return;
+                }
+
+                $target_post = $this->ensure_post_translation( $post );
+
+                if ( ! $target_post ) {
+                        return;
+                }
+
+                $this->enqueue_post_jobs( $post, $target_post, $update );
+        }
+
+        /**
+         * Ensure we react to created terms.
+         *
+         * @since 0.2.0
+         *
+         * @param int    $term_id  Term ID.
+         * @param int    $tt_id    Term taxonomy ID.
+         * @param string $taxonomy Taxonomy slug.
+         *
+         * @return void
+         */
+        public function handle_created_term( $term_id, $tt_id, $taxonomy ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+                if ( $this->is_assisted_mode() ) {
+                        return;
+                }
+
+                $this->sync_term_translation( $term_id, $taxonomy );
+        }
+
+        /**
+         * React to edited terms.
+         *
+         * @since 0.2.0
+         *
+         * @param int    $term_id  Term ID.
+         * @param int    $tt_id    Term taxonomy ID.
+         * @param string $taxonomy Taxonomy slug.
+         *
+         * @return void
+         */
+        public function handle_edited_term( $term_id, $tt_id, $taxonomy ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+                if ( $this->is_assisted_mode() ) {
+                        return;
+                }
+
+                $this->sync_term_translation( $term_id, $taxonomy );
+        }
+
+        /**
+         * Retrieve allowed post types for translation.
+         *
+         * @since 0.2.0
+         *
+         * @return array
+         */
+        protected function get_translatable_post_types() {
+                $post_types = get_post_types(
+                        array(
+                                'public' => true,
+                        ),
+                        'names'
+                );
+
+                if ( ! in_array( 'attachment', $post_types, true ) ) {
+                        $post_types[] = 'attachment';
+                }
+
+                $post_types = apply_filters( 'fpml_translatable_post_types', $post_types );
+
+                return array_filter( array_map( 'sanitize_key', $post_types ) );
+        }
+
+        /**
+         * Ensure a translation post exists and return it.
+         *
+         * @since 0.2.0
+         *
+         * @param WP_Post $post Source post.
+         *
+         * @return WP_Post|false
+         */
+        protected function ensure_post_translation( $post ) {
+                $target_id = (int) get_post_meta( $post->ID, '_fpml_pair_id', true );
+
+                if ( $target_id ) {
+                        $target_post = get_post( $target_id );
+
+                        if ( $target_post instanceof WP_Post ) {
+                                update_post_meta( $target_post->ID, '_fpml_pair_source_id', $post->ID );
+                                update_post_meta( $target_post->ID, '_fpml_is_translation', 1 );
+
+                                return $target_post;
+                        }
+                }
+
+                $this->creating_translation = true;
+
+                $postarr = array(
+                        'post_type'      => $post->post_type,
+                        'post_status'    => $post->post_status,
+                        'post_author'    => $post->post_author,
+                        'post_parent'    => $post->post_parent,
+                        'menu_order'     => $post->menu_order,
+                        'post_password'  => $post->post_password,
+                        'comment_status' => $post->comment_status,
+                        'ping_status'    => $post->ping_status,
+                        'post_title'     => '',
+                        'post_content'   => '',
+                        'post_excerpt'   => '',
+                        'post_name'      => '',
+                        'meta_input'     => array(
+                                '_fpml_is_translation'  => 1,
+                                '_fpml_pair_source_id' => $post->ID,
+                        ),
+                );
+
+                $target_id = wp_insert_post( $postarr, true );
+
+                $this->creating_translation = false;
+
+                if ( is_wp_error( $target_id ) ) {
+                        $this->logger->log(
+                                'error',
+                                sprintf( 'Impossibile creare la traduzione per il post #%d: %s', $post->ID, $target_id->get_error_message() ),
+                                array(
+                                        'post_id' => $post->ID,
+                                )
+                        );
+
+                        return false;
+                }
+
+                update_post_meta( $post->ID, '_fpml_pair_id', $target_id );
+
+                $target_post = get_post( $target_id );
+
+                if ( $target_post instanceof WP_Post ) {
+                        update_post_meta( $target_post->ID, '_fpml_pair_source_id', $post->ID );
+                        update_post_meta( $target_post->ID, '_fpml_is_translation', 1 );
+
+                        return $target_post;
+                }
+
+                return false;
+        }
+
+        /**
+         * Enqueue translation jobs for a pair of posts.
+         *
+         * @since 0.2.0
+         *
+         * @param WP_Post $source_post Italian source post.
+         * @param WP_Post $target_post English counterpart.
+         * @param bool    $update      Whether this is an update.
+         *
+         * @return void
+         */
+        protected function enqueue_post_jobs( $source_post, $target_post, $update ) {
+                $fields = array( 'post_title', 'post_excerpt', 'post_content' );
+
+                foreach ( $fields as $field ) {
+                        $hash = $this->hash_value( $this->get_post_field_value( $source_post, $field ) );
+
+                        if ( ! $hash ) {
+                                continue;
+                        }
+
+                        $this->queue->enqueue( 'post', $source_post->ID, $field, $hash );
+                        $this->update_post_status_flag( $target_post->ID, $field, 'needs_update' );
+                }
+
+                $meta_keys = $this->get_meta_whitelist();
+
+                foreach ( $meta_keys as $meta_key ) {
+                        if ( '' === $meta_key ) {
+                                continue;
+                        }
+
+                        $value = get_post_meta( $source_post->ID, $meta_key, true );
+                        $hash  = $this->hash_value( $value );
+
+                        if ( ! $hash ) {
+                                continue;
+                        }
+
+                        $field_key = 'meta:' . $meta_key;
+
+                        $this->queue->enqueue( 'post', $source_post->ID, $field_key, $hash );
+                        $this->update_post_status_flag( $target_post->ID, $field_key, 'needs_update' );
+                }
+
+                /**
+                 * Allow third parties to react when jobs are enqueued.
+                 *
+                 * @since 0.2.0
+                 *
+                 * @param WP_Post $source_post Source post.
+                 * @param WP_Post $target_post Target post.
+                 * @param bool    $update      Whether the post is being updated.
+                 */
+                do_action( 'fpml_post_jobs_enqueued', $source_post, $target_post, $update );
+        }
+
+        /**
+         * Retrieve a value for hashing from a post field.
+         *
+         * @since 0.2.0
+         *
+         * @param WP_Post $post  Post object.
+         * @param string  $field Field name.
+         *
+         * @return string
+         */
+        protected function get_post_field_value( $post, $field ) {
+                switch ( $field ) {
+                        case 'post_title':
+                                return (string) $post->post_title;
+                        case 'post_excerpt':
+                                return (string) $post->post_excerpt;
+                        case 'post_content':
+                                return (string) $post->post_content;
+                }
+
+                return '';
+        }
+
+        /**
+         * Parse whitelist meta keys.
+         *
+         * @since 0.2.0
+         *
+         * @return array
+         */
+        protected function get_meta_whitelist() {
+                $raw = $this->settings ? $this->settings->get( 'meta_whitelist', '' ) : '';
+
+                if ( ! is_string( $raw ) ) {
+                        return array();
+                }
+
+                $parts = preg_split( '/[\n,]+/', $raw );
+                $parts = array_map( 'trim', $parts );
+                $parts = array_filter( $parts );
+
+                $sanitized = array();
+
+                foreach ( $parts as $key ) {
+                        $key = preg_replace( '/[^a-zA-Z0-9_\-]/', '', $key );
+
+                        if ( '' !== $key ) {
+                                $sanitized[] = $key;
+                        }
+                }
+
+                /**
+                 * Allow other components to extend the meta whitelist.
+                 *
+                 * @since 0.2.0
+                 *
+                 * @param array         $sanitized Current whitelist.
+                 * @param FPML_Plugin   $plugin    Plugin instance.
+                 */
+                $sanitized = apply_filters( 'fpml_meta_whitelist', array_unique( $sanitized ), $this );
+
+                return array_values( array_unique( array_filter( $sanitized ) ) );
+        }
+
+        /**
+         * Generate a normalized hash for queue purposes.
+         *
+         * @since 0.2.0
+         *
+         * @param mixed $value Value to hash.
+         *
+         * @return string
+         */
+        protected function hash_value( $value ) {
+                if ( is_array( $value ) || is_object( $value ) ) {
+                        $value = wp_json_encode( $value );
+                }
+
+                $value = (string) $value;
+
+                if ( '' === $value ) {
+                        return md5( '' );
+                }
+
+                return md5( $value );
+        }
+
+        /**
+         * Update translation status flag on the translated post.
+         *
+         * @since 0.2.0
+         *
+         * @param int    $post_id Target post ID.
+         * @param string $field   Field identifier.
+         * @param string $status  Status slug.
+         *
+         * @return void
+         */
+        protected function update_post_status_flag( $post_id, $field, $status ) {
+                $meta_key = '_fpml_status_' . sanitize_key( str_replace( ':', '_', $field ) );
+
+                update_post_meta( $post_id, $meta_key, sanitize_key( $status ) );
+        }
+
+        /**
+         * Ensure taxonomy terms have an English counterpart.
+         *
+         * @since 0.2.0
+         *
+         * @param int    $term_id  Term ID.
+         * @param string $taxonomy Taxonomy slug.
+         *
+         * @return void
+         */
+        protected function sync_term_translation( $term_id, $taxonomy ) {
+                if ( $this->creating_term_translation ) {
+                        return;
+                }
+
+                $taxonomies = get_taxonomies(
+                        array(
+                                'public' => true,
+                        ),
+                        'names'
+                );
+
+                $taxonomies = apply_filters( 'fpml_translatable_taxonomies', $taxonomies );
+
+                if ( empty( $taxonomies ) || ! in_array( $taxonomy, $taxonomies, true ) ) {
+                        return;
+                }
+
+                $term = get_term( $term_id, $taxonomy );
+
+                if ( ! $term || is_wp_error( $term ) ) {
+                        return;
+                }
+
+                if ( get_term_meta( $term_id, '_fpml_is_translation', true ) ) {
+                        return;
+                }
+
+                $target_id = (int) get_term_meta( $term_id, '_fpml_pair_id', true );
+
+                if ( $target_id ) {
+                        $target_term = get_term( $target_id, $taxonomy );
+                } else {
+                        $target_term = $this->create_term_translation( $term );
+
+                        if ( ! $target_term ) {
+                                return;
+                        }
+
+                        $target_id = (int) $target_term->term_id;
+                        update_term_meta( $term_id, '_fpml_pair_id', $target_id );
+                }
+
+                if ( ! $target_term ) {
+                        return;
+                }
+
+                update_term_meta( $target_term->term_id, '_fpml_pair_source_id', $term->term_id );
+                update_term_meta( $target_term->term_id, '_fpml_is_translation', 1 );
+
+                $this->queue->enqueue( 'term', $term->term_id, 'name', $this->hash_value( $term->name ) );
+                $this->queue->enqueue( 'term', $term->term_id, 'description', $this->hash_value( $term->description ) );
+
+                update_term_meta( $target_term->term_id, '_fpml_status_name', 'needs_update' );
+                update_term_meta( $target_term->term_id, '_fpml_status_description', 'needs_update' );
+        }
+
+        /**
+         * Create a translated term shell.
+         *
+         * @since 0.2.0
+         *
+         * @param WP_Term $term Source term.
+         *
+         * @return WP_Term|false
+         */
+        protected function create_term_translation( $term ) {
+                $this->creating_term_translation = true;
+
+                $args = array(
+                        'slug'       => $this->generate_translation_slug( $term->slug ),
+                        'parent'     => $term->parent,
+                        'description'=> '',
+                        'meta_input' => array(
+                                '_fpml_is_translation'  => 1,
+                                '_fpml_pair_source_id' => $term->term_id,
+                        ),
+                );
+
+                $result = wp_insert_term( $term->name, $term->taxonomy, $args );
+
+                $this->creating_term_translation = false;
+
+                if ( is_wp_error( $result ) ) {
+                        $this->logger->log(
+                                'error',
+                                sprintf( 'Impossibile creare la traduzione del termine #%d: %s', $term->term_id, $result->get_error_message() ),
+                                array(
+                                        'term_id'  => $term->term_id,
+                                        'taxonomy' => $term->taxonomy,
+                                )
+                        );
+
+                        return false;
+                }
+
+                if ( empty( $result['term_id'] ) ) {
+                        return false;
+                }
+
+                update_term_meta( $result['term_id'], '_fpml_pair_source_id', $term->term_id );
+                update_term_meta( $result['term_id'], '_fpml_is_translation', 1 );
+
+                return get_term( (int) $result['term_id'], $term->taxonomy );
+        }
+
+        /**
+         * Generate a slug candidate for the translated entity.
+         *
+         * @since 0.2.0
+         *
+         * @param string $slug Source slug.
+         *
+         * @return string
+         */
+        protected function generate_translation_slug( $slug ) {
+                $slug = sanitize_title( $slug );
+
+                if ( '' === $slug ) {
+                        $slug = uniqid( 'fpml-en-' );
+                }
+
+                if ( '-en' !== substr( $slug, -3 ) ) {
+                        $slug .= '-en';
+                }
+
+                return $slug;
+        }
+
+        /**
+         * Reindex existing content to ensure queue coverage and translations.
+         *
+         * @since 0.2.0
+         *
+         * @return array Summary data.
+         */
+        public function reindex_content() {
+                if ( $this->is_assisted_mode() ) {
+                        return new WP_Error(
+                                'fpml_assisted_mode',
+                                __( 'La modalità assistita è attiva: la duplicazione e il reindex automatico sono disabilitati.', 'fp-multilanguage' )
+                        );
+                }
+
+                $summary = array(
+                        'posts_scanned'        => 0,
+                        'posts_enqueued'       => 0,
+                        'translations_created' => 0,
+                        'terms_scanned'        => 0,
+                        'menus_synced'         => 0,
+                );
+
+                $post_types = $this->get_translatable_post_types();
+
+                foreach ( $post_types as $post_type ) {
+                        $paged = 1;
+
+                        do {
+                                $query = new WP_Query(
+                                        array(
+                                                'post_type'      => $post_type,
+                                                'post_status'    => 'any',
+                                                'posts_per_page' => 100,
+                                                'paged'          => $paged,
+                                                'fields'         => 'ids',
+                                                'orderby'        => 'ID',
+                                                'order'          => 'ASC',
+                                        )
+                                );
+
+                                if ( ! $query->have_posts() ) {
+                                        break;
+                                }
+
+                                foreach ( $query->posts as $post_id ) {
+                                        $post = get_post( $post_id );
+
+                                        if ( ! $post instanceof WP_Post ) {
+                                                continue;
+                                        }
+
+                                        if ( get_post_meta( $post->ID, '_fpml_is_translation', true ) ) {
+                                                continue;
+                                        }
+
+                                        $summary['posts_scanned']++;
+
+                                        $existing_target = (int) get_post_meta( $post->ID, '_fpml_pair_id', true );
+                                        $target_post     = $this->ensure_post_translation( $post );
+
+                                        if ( ! $target_post ) {
+                                                continue;
+                                        }
+
+                                        if ( ! $existing_target ) {
+                                                $summary['translations_created']++;
+                                        }
+
+                                        $this->enqueue_post_jobs( $post, $target_post, true );
+                                        $summary['posts_enqueued']++;
+                                }
+
+                                $paged++;
+                        } while ( $paged <= $query->max_num_pages );
+
+                        wp_reset_postdata();
+                }
+
+                $taxonomies = get_taxonomies(
+                        array(
+                                'public' => true,
+                        ),
+                        'names'
+                );
+
+                $taxonomies = apply_filters( 'fpml_translatable_taxonomies', $taxonomies );
+
+                foreach ( $taxonomies as $taxonomy ) {
+                        $terms = get_terms(
+                                array(
+                                        'taxonomy'   => $taxonomy,
+                                        'hide_empty' => false,
+                                        'fields'     => 'ids',
+                                )
+                        );
+
+                        if ( is_wp_error( $terms ) ) {
+                                continue;
+                        }
+
+                        foreach ( $terms as $term_id ) {
+                                if ( get_term_meta( $term_id, '_fpml_is_translation', true ) ) {
+                                        continue;
+                                }
+
+                                $summary['terms_scanned']++;
+                                $this->sync_term_translation( $term_id, $taxonomy );
+                        }
+                }
+
+                $menu_sync = FPML_Menu_Sync::instance();
+
+                if ( $menu_sync instanceof FPML_Menu_Sync ) {
+                        $summary['menus_synced'] = $menu_sync->resync_all();
+                }
+
+                /**
+                 * Allow filtering of the reindex summary before returning.
+                 *
+                 * @since 0.2.0
+                 *
+                 * @param array         $summary Summary data.
+                 * @param FPML_Plugin   $plugin  Plugin instance.
+                 */
+                return apply_filters( 'fpml_reindex_summary', $summary, $this );
+        }
+
+        /**
+         * Build a diagnostics snapshot for the admin dashboard.
+         *
+         * @since 0.2.0
+         *
+         * @return array<string,mixed>
+         */
+        public function get_diagnostics_snapshot() {
+                if ( $this->is_assisted_mode() ) {
+                        return array(
+                                'assisted_mode'   => true,
+                                'assisted_reason' => $this->assisted_reason,
+                                'message'         => __( 'WPML o Polylang sono attivi: la gestione della coda è disabilitata e le metriche non sono disponibili.', 'fp-multilanguage' ),
+                        );
+                }
+
+                $queue      = FPML_Queue::instance();
+                $processor  = FPML_Processor::instance();
+                $logger     = FPML_Logger::instance();
+                $settings   = $this->settings;
+                $counts     = $queue->get_state_counts();
+                $events     = array(
+                        'fpml_run_queue'       => wp_next_scheduled( 'fpml_run_queue' ),
+                        'fpml_retry_failed'    => wp_next_scheduled( 'fpml_retry_failed' ),
+                        'fpml_resync_outdated' => wp_next_scheduled( 'fpml_resync_outdated' ),
+                );
+                $logs       = $logger->get_logs( 25 );
+                $log_stats  = $logger->get_stats();
+                $estimate   = $this->estimate_queue_cost();
+                $estimate_error = '';
+
+                if ( is_wp_error( $estimate ) ) {
+                        $estimate_error = $estimate->get_error_message();
+                        $estimate       = array(
+                                'characters'     => 0,
+                                'estimated_cost' => 0.0,
+                                'jobs_scanned'   => 0,
+                                'word_count'     => 0,
+                        );
+                }
+
+                $translator = $processor->get_translator_instance();
+                $translator_status = array(
+                        'provider'   => $settings ? $settings->get( 'provider', '' ) : '',
+                        'configured' => ! is_wp_error( $translator ) && $translator instanceof FPML_TranslatorInterface,
+                        'error'      => is_wp_error( $translator ) ? $translator->get_error_message() : '',
+                );
+
+                $batch_durations = array();
+                $batch_jobs      = array();
+                $recent_errors   = array();
+
+                foreach ( $logs as $entry ) {
+                        if ( isset( $entry['level'] ) && 'error' === $entry['level'] ) {
+                                $recent_errors[] = $entry;
+                        }
+
+                        if ( empty( $entry['message'] ) ) {
+                                continue;
+                        }
+
+                        if ( false !== strpos( $entry['message'], 'Batch coda completato' ) ) {
+                                if ( preg_match( '/([0-9]+(?:\.[0-9]+)?)s/', $entry['message'], $matches ) ) {
+                                        $batch_durations[] = (float) $matches[1];
+                                }
+
+                                if ( isset( $entry['context']['jobs'] ) ) {
+                                        $batch_jobs[] = (float) $entry['context']['jobs'];
+                                }
+                        }
+                }
+
+                $average_duration = ! empty( $batch_durations ) ? array_sum( $batch_durations ) / count( $batch_durations ) : 0.0;
+                $average_jobs     = ! empty( $batch_jobs ) ? array_sum( $batch_jobs ) / count( $batch_jobs ) : 0.0;
+
+                return array(
+                        'queue_counts'      => $counts,
+                        'events'            => $events,
+                        'lock_active'       => $processor->is_locked(),
+                        'cron_disabled'     => defined( 'DISABLE_WP_CRON' ) && DISABLE_WP_CRON,
+                        'logs'              => $logs,
+                        'log_stats'         => $log_stats,
+                        'estimate'          => $estimate,
+                        'estimate_error'    => $estimate_error,
+                        'translator_status' => $translator_status,
+                        'batch_average'     => array(
+                                'duration' => $average_duration,
+                                'jobs'     => $average_jobs,
+                        ),
+                        'recent_errors'     => array_slice( $recent_errors, 0, 5 ),
+                );
+        }
+
+        /**
+         * Estimate characters, words and cost for jobs in the queue.
+         *
+         * @since 0.2.0
+         *
+         * @param array<string>|null $states   Queue states to inspect.
+         * @param int                $max_jobs Maximum number of jobs to analyse.
+         *
+         * @return array<string,float|int>|WP_Error
+         */
+        public function estimate_queue_cost( $states = null, $max_jobs = 500 ) {
+                if ( $this->is_assisted_mode() ) {
+                        return new WP_Error(
+                                'fpml_assisted_mode',
+                                __( 'La modalità assistita è attiva: la coda è gestita esternamente, nessuna stima disponibile.', 'fp-multilanguage' )
+                        );
+                }
+
+                $processor  = FPML_Processor::instance();
+                $translator = $processor->get_translator_instance();
+
+                if ( is_wp_error( $translator ) ) {
+                        return $translator;
+                }
+
+                if ( null === $states ) {
+                        $states = array( 'pending', 'outdated', 'translating' );
+                }
+
+                $states = array_filter( array_map( 'sanitize_key', (array) $states ) );
+
+                if ( empty( $states ) ) {
+                        return array(
+                                'characters'     => 0,
+                                'estimated_cost' => 0.0,
+                                'jobs_scanned'   => 0,
+                                'word_count'     => 0,
+                        );
+                }
+
+                $max_jobs = max( 1, absint( $max_jobs ) );
+
+                $queue       = FPML_Queue::instance();
+                $batch_limit = (int) apply_filters( 'fpml_estimate_batch_size', 100 );
+                $characters  = 0;
+                $cost        = 0.0;
+                $word_count  = 0;
+                $offset      = 0;
+                $scanned     = 0;
+
+                while ( $scanned < $max_jobs ) {
+                        $limit = min( $batch_limit, $max_jobs - $scanned );
+                        $jobs  = $queue->get_jobs_for_states( $states, $limit, $offset );
+
+                        if ( empty( $jobs ) ) {
+                                break;
+                        }
+
+                        foreach ( $jobs as $job ) {
+                                $text = $this->get_queue_job_text( $job );
+
+                                if ( '' === trim( (string) $text ) ) {
+                                        continue;
+                                }
+
+                                $length      = function_exists( 'mb_strlen' ) ? mb_strlen( $text, 'UTF-8' ) : strlen( $text );
+                                $characters += $length;
+                                $cost       += (float) $translator->estimate_cost( $text );
+
+                                $words = trim( wp_strip_all_tags( $text ) );
+                                if ( '' !== $words ) {
+                                        $word_count += count( preg_split( '/\s+/u', $words ) );
+                                }
+                        }
+
+                        $count   = count( $jobs );
+                        $scanned += $count;
+                        $offset  += $count;
+
+                        if ( $count < $limit ) {
+                                break;
+                        }
+                }
+
+                return array(
+                        'characters'     => (int) $characters,
+                        'estimated_cost' => (float) $cost,
+                        'jobs_scanned'   => (int) $scanned,
+                        'word_count'     => (int) $word_count,
+                );
+        }
+
+        /**
+         * Retrieve the raw text associated with a queue job.
+         *
+         * @since 0.2.0
+         *
+         * @param object $job Queue job entry.
+         *
+         * @return string
+         */
+        public function get_queue_job_text( $job ) {
+                if ( ! is_object( $job ) || empty( $job->object_type ) ) {
+                        return '';
+                }
+
+                if ( 'post' !== $job->object_type ) {
+                        return '';
+                }
+
+                $post = get_post( isset( $job->object_id ) ? (int) $job->object_id : 0 );
+
+                if ( ! $post instanceof WP_Post ) {
+                        return '';
+                }
+
+                $field = isset( $job->field ) ? (string) $job->field : '';
+
+                if ( 0 === strpos( $field, 'meta:' ) ) {
+                        $meta_key = substr( $field, 5 );
+                        $value    = get_post_meta( $post->ID, $meta_key, true );
+
+                        if ( is_array( $value ) || is_object( $value ) ) {
+                                $value = wp_json_encode( $value );
+                        }
+
+                        return (string) $value;
+                }
+
+                switch ( $field ) {
+                        case 'post_title':
+                                return (string) $post->post_title;
+                        case 'post_excerpt':
+                                return (string) $post->post_excerpt;
+                        case 'post_content':
+                                return (string) $post->post_content;
+                }
+
+                return '';
+        }
+}

--- a/fp-multilanguage/includes/class-queue.php
+++ b/fp-multilanguage/includes/class-queue.php
@@ -1,0 +1,534 @@
+<?php
+/**
+ * Queue handler for translation jobs.
+ *
+ * @package FP_Multilanguage
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+        exit;
+}
+
+/**
+ * Manage the wp_fpml_queue table and CRUD operations.
+ *
+ * @since 0.2.0
+ */
+class FPML_Queue {
+        /**
+         * Singleton instance.
+         *
+         * @var FPML_Queue|null
+         */
+        protected static $instance = null;
+
+        /**
+         * Cached table name.
+         *
+         * @var string
+         */
+        protected $table = '';
+
+        /**
+         * Retrieve singleton instance.
+         *
+         * @since 0.2.0
+         *
+         * @return FPML_Queue
+         */
+        public static function instance() {
+                if ( null === self::$instance ) {
+                        self::$instance = new self();
+                }
+
+                return self::$instance;
+        }
+
+        /**
+         * Constructor.
+         */
+        protected function __construct() {
+                global $wpdb;
+
+                $this->table = $wpdb->prefix . 'fpml_queue';
+
+                $this->register_table_name();
+        }
+
+        /**
+         * Ensure global $wpdb has the custom table registered for caching purposes.
+         *
+         * @since 0.2.0
+         *
+         * @return void
+         */
+        public function register_table_name() {
+                global $wpdb;
+
+                if ( ! in_array( 'fpml_queue', $wpdb->tables, true ) ) {
+                        $wpdb->tables[] = 'fpml_queue';
+                }
+
+                $wpdb->fpml_queue = $this->table;
+        }
+
+        /**
+         * Get the fully qualified table name.
+         *
+         * @since 0.2.0
+         *
+         * @return string
+         */
+        public function get_table() {
+                return $this->table;
+        }
+
+        /**
+         * Install database table using dbDelta.
+         *
+         * @since 0.2.0
+         *
+         * @return void
+         */
+        public function install() {
+                global $wpdb;
+
+                require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+
+                $charset_collate = $wpdb->get_charset_collate();
+                $table           = $this->get_table();
+
+                $sql = "CREATE TABLE {$table} (
+                        id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+                        object_type varchar(32) NOT NULL,
+                        object_id bigint(20) unsigned NOT NULL,
+                        field varchar(191) NOT NULL,
+                        hash_source varchar(64) NOT NULL DEFAULT '',
+                        state varchar(20) NOT NULL DEFAULT 'pending',
+                        retries smallint(5) unsigned NOT NULL DEFAULT 0,
+                        last_error text NULL,
+                        created_at datetime NOT NULL,
+                        updated_at datetime NOT NULL,
+                        PRIMARY KEY  (id),
+                        KEY object_lookup (object_type, object_id),
+                        KEY state_lookup (state),
+                        UNIQUE KEY object_field (object_type, object_id, field)
+                ) {$charset_collate};";
+
+                dbDelta( $sql );
+        }
+
+        /**
+         * Enqueue or update a job.
+         *
+         * @since 0.2.0
+         *
+         * @param string $object_type Object type.
+         * @param int    $object_id   Object ID.
+         * @param string $field       Field identifier.
+         * @param string $hash_source Hash of the source payload.
+         *
+         * @return int Job ID.
+         */
+        public function enqueue( $object_type, $object_id, $field, $hash_source ) {
+                global $wpdb;
+
+                $object_type = sanitize_key( $object_type );
+                $object_id   = absint( $object_id );
+                $field       = sanitize_text_field( $field );
+                $hash_source = sanitize_text_field( $hash_source );
+
+                if ( empty( $object_type ) || empty( $object_id ) || empty( $field ) ) {
+                        return 0;
+                }
+
+                $table = $this->get_table();
+                $now   = current_time( 'mysql', true );
+
+                $existing = $wpdb->get_row(
+                        $wpdb->prepare(
+                                "SELECT id, hash_source, state FROM {$table} WHERE object_type = %s AND object_id = %d AND field = %s",
+                                $object_type,
+                                $object_id,
+                                $field
+                        )
+                );
+
+                if ( $existing ) {
+                        $data    = array(
+                                'hash_source' => $hash_source,
+                                'updated_at'  => $now,
+                        );
+                        $formats = array( '%s', '%s' );
+
+                        if ( $existing->hash_source !== $hash_source || 'done' !== $existing->state ) {
+                                $data['state']      = 'pending';
+                                $data['retries']    = 0;
+                                $data['last_error'] = '';
+                                $formats[]          = '%s';
+                                $formats[]          = '%d';
+                                $formats[]          = '%s';
+                        }
+
+                        $wpdb->update(
+                                $table,
+                                $data,
+                                array( 'id' => (int) $existing->id ),
+                                $formats,
+                                array( '%d' )
+                        );
+
+                        return (int) $existing->id;
+                }
+
+                $inserted = $wpdb->insert(
+                        $table,
+                        array(
+                                'object_type' => $object_type,
+                                'object_id'   => $object_id,
+                                'field'       => $field,
+                                'hash_source' => $hash_source,
+                                'state'       => 'pending',
+                                'retries'     => 0,
+                                'last_error'  => '',
+                                'created_at'  => $now,
+                                'updated_at'  => $now,
+                        ),
+                        array( '%s', '%d', '%s', '%s', '%s', '%d', '%s', '%s', '%s' )
+                );
+
+                if ( false === $inserted ) {
+                        return 0;
+                }
+
+                return (int) $wpdb->insert_id;
+        }
+
+        /**
+         * Claim a batch of jobs for processing.
+         *
+         * @since 0.2.0
+         *
+         * @param int $limit Limit.
+         *
+         * @return array
+         */
+        public function claim_batch( $limit = 5 ) {
+                global $wpdb;
+
+                $limit = max( 1, absint( $limit ) );
+                $table = $this->get_table();
+
+                $states       = array( 'pending', 'outdated' );
+                $placeholders = implode( ',', array_fill( 0, count( $states ), '%s' ) );
+                $sql          = "SELECT * FROM {$table} WHERE state IN ({$placeholders}) ORDER BY created_at ASC LIMIT %d";
+                $prepared     = array_merge( $states, array( $limit ) );
+
+                $sql   = call_user_func_array( array( $wpdb, 'prepare' ), array_merge( array( $sql ), $prepared ) );
+                $items = $wpdb->get_results( $sql );
+
+                if ( empty( $items ) ) {
+                        return array();
+                }
+
+                $now = current_time( 'mysql', true );
+
+                foreach ( $items as $item ) {
+                        $wpdb->update(
+                                $table,
+                                array(
+                                        'state'      => 'translating',
+                                        'updated_at' => $now,
+                                ),
+                                array( 'id' => (int) $item->id ),
+                                array( '%s', '%s' ),
+                                array( '%d' )
+                        );
+
+                        $item->state      = 'translating';
+                        $item->updated_at = $now;
+                }
+
+                return $items;
+        }
+
+        /**
+         * Update job state.
+         *
+         * @since 0.2.0
+         *
+         * @param int    $job_id Job ID.
+         * @param string $state  New state.
+         * @param string $error  Optional error message.
+         *
+         * @return bool
+         */
+        public function update_state( $job_id, $state, $error = '' ) {
+                global $wpdb;
+
+                $job_id = absint( $job_id );
+                $state  = sanitize_key( $state );
+                $error  = wp_kses_post( $error );
+
+                if ( ! $job_id || empty( $state ) ) {
+                        return false;
+                }
+
+                $table = $this->get_table();
+                $now   = current_time( 'mysql', true );
+
+                $current = $wpdb->get_row(
+                        $wpdb->prepare( "SELECT retries FROM {$table} WHERE id = %d", $job_id )
+                );
+
+                $retries = $current ? (int) $current->retries : 0;
+
+                if ( in_array( $state, array( 'pending', 'done' ), true ) ) {
+                        $retries = 0;
+                } elseif ( 'error' === $state ) {
+                        $retries++; // count failures.
+                }
+
+                $data = array(
+                        'state'      => $state,
+                        'updated_at' => $now,
+                        'retries'    => $retries,
+                );
+
+                if ( ! empty( $error ) ) {
+                        $data['last_error'] = $error;
+                } elseif ( 'pending' === $state ) {
+                        $data['last_error'] = '';
+                }
+
+                $formats = array( '%s', '%s', '%d' );
+
+                if ( array_key_exists( 'last_error', $data ) ) {
+                        $formats[] = '%s';
+                }
+
+                return (bool) $wpdb->update(
+                        $table,
+                        $data,
+                        array( 'id' => $job_id ),
+                        $formats,
+                        array( '%d' )
+                );
+        }
+
+        /**
+         * Reset retries counter manually.
+         *
+         * @since 0.2.0
+         *
+         * @param int $job_id Job ID.
+         *
+         * @return bool
+         */
+        public function reset_retries( $job_id ) {
+                global $wpdb;
+
+                $job_id = absint( $job_id );
+
+                if ( ! $job_id ) {
+                        return false;
+                }
+
+                return (bool) $wpdb->update(
+                        $this->get_table(),
+                        array( 'retries' => 0 ),
+                        array( 'id' => $job_id ),
+                        array( '%d' ),
+                        array( '%d' )
+                );
+        }
+
+        /**
+         * Retrieve jobs by state.
+         *
+         * @since 0.2.0
+         *
+         * @param array $states States list.
+         * @param int   $limit  Limit.
+         *
+         * @return array
+         */
+        public function get_by_state( $states, $limit = 50 ) {
+                global $wpdb;
+
+                $states = array_filter( array_map( 'sanitize_key', (array) $states ) );
+                $limit  = max( 1, absint( $limit ) );
+
+                if ( empty( $states ) ) {
+                        return array();
+                }
+
+                $table        = $this->get_table();
+                $placeholders = implode( ',', array_fill( 0, count( $states ), '%s' ) );
+                $sql          = "SELECT * FROM {$table} WHERE state IN ({$placeholders}) ORDER BY updated_at DESC LIMIT %d";
+                $prepared     = array_merge( $states, array( $limit ) );
+
+                $sql = call_user_func_array( array( $wpdb, 'prepare' ), array_merge( array( $sql ), $prepared ) );
+
+                return $wpdb->get_results( $sql );
+        }
+
+        /**
+         * Delete a job from the queue.
+         *
+         * @since 0.2.0
+         *
+         * @param int $job_id Job ID.
+         *
+         * @return bool
+         */
+        public function delete( $job_id ) {
+                global $wpdb;
+
+                $job_id = absint( $job_id );
+
+                if ( ! $job_id ) {
+                        return false;
+                }
+
+                return (bool) $wpdb->delete( $this->get_table(), array( 'id' => $job_id ), array( '%d' ) );
+        }
+
+        /**
+         * Bulk mark jobs for a specific object as outdated.
+         *
+         * @since 0.2.0
+         *
+         * @param string $object_type Object type.
+         * @param int    $object_id   Object ID.
+         *
+         * @return void
+         */
+        public function mark_outdated( $object_type, $object_id ) {
+                global $wpdb;
+
+                $object_type = sanitize_key( $object_type );
+                $object_id   = absint( $object_id );
+
+                if ( empty( $object_type ) || ! $object_id ) {
+                        return;
+                }
+
+                $wpdb->update(
+                        $this->get_table(),
+                        array(
+                                'state'      => 'outdated',
+                                'updated_at' => current_time( 'mysql', true ),
+                        ),
+                        array(
+                                'object_type' => $object_type,
+                                'object_id'   => $object_id,
+                        ),
+                        array( '%s', '%s' ),
+                        array( '%s', '%d' )
+                );
+        }
+
+        /**
+         * Purge completed jobs older than a threshold.
+         *
+         * @since 0.2.0
+         *
+         * @param int $days Days threshold.
+         *
+         * @return int Deleted rows.
+         */
+        public function purge_completed( $days = 30 ) {
+                global $wpdb;
+
+                $days = max( 1, absint( $days ) );
+
+                $threshold = gmdate( 'Y-m-d H:i:s', strtotime( '-' . $days . ' days' ) );
+
+                $sql = 'DELETE FROM ' . $this->get_table() . " WHERE state IN ('done','skipped') AND updated_at < %s";
+
+                return (int) $wpdb->query( $wpdb->prepare( $sql, $threshold ) );
+        }
+
+        /**
+         * Retrieve counts grouped by state.
+         *
+         * @since 0.2.0
+         *
+         * @return array<string,int>
+         */
+        public function get_state_counts() {
+                global $wpdb;
+
+                $results = $wpdb->get_results( 'SELECT state, COUNT(*) AS total FROM ' . $this->get_table() . ' GROUP BY state' );
+
+                $counts = array();
+
+                foreach ( (array) $results as $row ) {
+                        if ( isset( $row->state ) ) {
+                                $counts[ $row->state ] = isset( $row->total ) ? (int) $row->total : 0;
+                        }
+                }
+
+                return $counts;
+        }
+
+        /**
+         * Reset specific states back to pending.
+         *
+         * @since 0.2.0
+         *
+         * @param array $states States to reset.
+         *
+         * @return int Updated rows.
+         */
+        public function reset_states( $states = array( 'translating' ) ) {
+                global $wpdb;
+
+                $states = array_filter( array_map( 'sanitize_key', (array) $states ) );
+
+                if ( empty( $states ) ) {
+                        return 0;
+                }
+
+                $placeholders = implode( ',', array_fill( 0, count( $states ), '%s' ) );
+                $sql          = 'UPDATE ' . $this->get_table() . " SET state = 'pending', retries = 0, last_error = '', updated_at = %s WHERE state IN ({$placeholders})";
+
+                $params = array_merge( array( current_time( 'mysql', true ) ), $states );
+
+                $prepared = call_user_func_array( array( $wpdb, 'prepare' ), array_merge( array( $sql ), $params ) );
+
+                return (int) $wpdb->query( $prepared );
+        }
+
+        /**
+         * Fetch jobs for a given set of states.
+         *
+         * @since 0.2.0
+         *
+         * @param array $states States to include.
+         * @param int   $limit  Batch size.
+         * @param int   $offset Offset for pagination.
+         *
+         * @return array
+         */
+        public function get_jobs_for_states( $states, $limit = 50, $offset = 0 ) {
+                global $wpdb;
+
+                $states = array_filter( array_map( 'sanitize_key', (array) $states ) );
+                $limit  = max( 1, absint( $limit ) );
+                $offset = max( 0, absint( $offset ) );
+
+                if ( empty( $states ) ) {
+                        return array();
+                }
+
+                $placeholders = implode( ',', array_fill( 0, count( $states ), '%s' ) );
+                $sql          = 'SELECT * FROM ' . $this->get_table() . " WHERE state IN ({$placeholders}) ORDER BY id ASC LIMIT %d OFFSET %d";
+                $params       = array_merge( $states, array( $limit, $offset ) );
+
+                $sql = call_user_func_array( array( $wpdb, 'prepare' ), array_merge( array( $sql ), $params ) );
+
+                return $wpdb->get_results( $sql );
+        }
+}

--- a/fp-multilanguage/includes/class-rewrites.php
+++ b/fp-multilanguage/includes/class-rewrites.php
@@ -1,0 +1,179 @@
+<?php
+/**
+ * Rewrite rules and routing utilities.
+ *
+ * @package FP_Multilanguage
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Handle custom rewrites for the English locale.
+ *
+ * @since 0.2.0
+ */
+class FPML_Rewrites {
+    /**
+     * Singleton instance.
+     *
+     * @var FPML_Rewrites|null
+     */
+    protected static $instance = null;
+
+    /**
+     * Retrieve singleton instance.
+     *
+     * @since 0.2.0
+     *
+     * @return FPML_Rewrites
+     */
+    public static function instance() {
+        if ( null === self::$instance ) {
+            self::$instance = new self();
+        }
+
+        return self::$instance;
+    }
+
+    /**
+     * Constructor.
+     */
+    protected function __construct() {
+        add_action( 'init', array( $this, 'register_rewrites' ) );
+        add_filter( 'query_vars', array( $this, 'register_query_vars' ) );
+        add_filter( 'request', array( $this, 'handle_request_overrides' ) );
+    }
+
+    /**
+     * Register rewrite rules for the /en/ prefix when enabled.
+     *
+     * @since 0.2.0
+     *
+     * @return void
+     */
+    public function register_rewrites() {
+        add_rewrite_rule( '^sitemap-en\.xml$', 'index.php?fpml_sitemap=en', 'top' );
+
+        $settings = FPML_Settings::instance();
+
+        if ( 'segment' !== $settings->get( 'routing_mode', 'segment' ) ) {
+            return;
+        }
+
+        add_rewrite_tag( '%fpml_path%', '(.+)' );
+
+        add_rewrite_rule( '^en/?$', 'index.php?fpml_lang=en', 'top' );
+        add_rewrite_rule( '^en/(.+)/?$', 'index.php?fpml_lang=en&fpml_path=$matches[1]', 'top' );
+    }
+
+    /**
+     * Register custom query vars.
+     *
+     * @since 0.2.0
+     *
+     * @param array $vars Query vars.
+     *
+     * @return array
+     */
+    public function register_query_vars( $vars ) {
+        $vars[] = 'fpml_lang';
+        $vars[] = 'fpml_path';
+        $vars[] = 'fpml_sitemap';
+
+        return $vars;
+    }
+
+    /**
+     * Normalize request variables for language routing.
+     *
+     * @since 0.2.0
+     *
+     * @param array $request Request vars.
+     *
+     * @return array
+     */
+    public function handle_request_overrides( $request ) {
+        if ( is_admin() || defined( 'REST_REQUEST' ) ) {
+            return $request;
+        }
+
+        if ( isset( $request['lang'] ) ) {
+            if ( 'en' === strtolower( sanitize_text_field( $request['lang'] ) ) ) {
+                $request['fpml_lang'] = 'en';
+            }
+
+            unset( $request['lang'] );
+        }
+
+        if ( empty( $request['fpml_lang'] ) || 'en' !== $request['fpml_lang'] ) {
+            return $request;
+        }
+
+        if ( isset( $request['fpml_path'] ) ) {
+            $mapped = $this->map_path_to_query( $request['fpml_path'] );
+
+            unset( $request['fpml_path'] );
+
+            if ( ! empty( $mapped ) ) {
+                $request = array_merge( $request, $mapped );
+            }
+        }
+
+        return $request;
+    }
+
+    /**
+     * Attempt to map a rewritten path back to core query vars.
+     *
+     * @since 0.2.0
+     *
+     * @param string $path Original path.
+     *
+     * @return array
+     */
+    protected function map_path_to_query( $path ) {
+        $path = trim( (string) $path );
+
+        if ( '' === $path ) {
+            return array();
+        }
+
+        $path = trim( $path, '/' );
+
+        if ( '' === $path ) {
+            return array();
+        }
+
+        $home_url = home_url( '/' . $path . '/' );
+        $post_id  = url_to_postid( $home_url );
+
+        if ( $post_id ) {
+            return array(
+                'page_id' => $post_id,
+            );
+        }
+
+        $segments = explode( '/', $path );
+        $slug     = end( $segments );
+
+        $public_taxonomies = get_taxonomies( array( 'public' => true ), 'names' );
+
+        foreach ( $public_taxonomies as $taxonomy ) {
+            $term = get_term_by( 'slug', $slug, $taxonomy );
+
+            if ( $term && ! is_wp_error( $term ) ) {
+                return array(
+                    'taxonomy' => $taxonomy,
+                    'term'     => $term->slug,
+                );
+            }
+        }
+
+        return array(
+            'name'      => $slug,
+            'post_type' => 'any',
+        );
+    }
+}

--- a/fp-multilanguage/includes/class-seo.php
+++ b/fp-multilanguage/includes/class-seo.php
@@ -1,0 +1,1143 @@
+<?php
+/**
+ * SEO orchestration: meta synchronization, hreflang, canonical and slug utilities.
+ *
+ * @package FP_Multilanguage
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+        exit;
+}
+
+/**
+ * Handle SEO related responsibilities for translated content.
+ *
+ * @since 0.2.0
+ */
+class FPML_SEO {
+        /**
+         * Singleton instance.
+         *
+         * @var FPML_SEO|null
+         */
+        protected static $instance = null;
+
+        /**
+         * Cached settings handler.
+         *
+         * @var FPML_Settings
+         */
+        protected $settings;
+
+        /**
+         * Cached language helper.
+         *
+         * @var FPML_Language
+         */
+        protected $language;
+
+        /**
+         * Cached queue handler.
+         *
+         * @var FPML_Queue
+         */
+        protected $queue;
+
+        /**
+         * Cached logger instance.
+         *
+         * @var FPML_Logger
+         */
+        protected $logger;
+
+        /**
+         * Retrieve singleton instance.
+         *
+         * @since 0.2.0
+         *
+         * @return FPML_SEO
+         */
+        public static function instance() {
+                if ( null === self::$instance ) {
+                        self::$instance = new self();
+                }
+
+                return self::$instance;
+        }
+
+        /**
+         * Constructor.
+         */
+        protected function __construct() {
+                $this->settings = FPML_Settings::instance();
+                $this->language = FPML_Language::instance();
+                $this->queue    = FPML_Queue::instance();
+                $this->logger   = FPML_Logger::instance();
+
+                add_filter( 'fpml_meta_whitelist', array( $this, 'register_seo_meta_keys' ) );
+                add_action( 'fpml_post_jobs_enqueued', array( $this, 'maybe_enqueue_slug_job' ), 20, 3 );
+                add_action( 'wp_head', array( $this, 'render_head_tags' ), 5 );
+                add_action( 'template_redirect', array( $this, 'maybe_render_sitemap' ), 0 );
+                add_action( 'template_redirect', array( $this, 'handle_legacy_slug_redirects' ), 1 );
+
+                add_filter( 'wpseo_canonical', array( $this, 'filter_canonical_url' ) );
+                add_filter( 'rank_math/frontend/canonical', array( $this, 'filter_canonical_url' ) );
+                add_filter( 'aioseo_canonical_url', array( $this, 'filter_canonical_url' ) );
+
+                add_filter( 'wpseo_robots', array( $this, 'filter_robots_directive' ) );
+                add_filter( 'rank_math/frontend/robots', array( $this, 'filter_rankmath_robots' ) );
+
+                add_filter( 'wpseo_sitemap_index', array( $this, 'inject_wpseo_sitemap_entry' ) );
+                add_filter( 'rank_math/sitemap/index', array( $this, 'inject_rankmath_sitemap_entry' ) );
+                add_filter( 'aioseo_sitemap_indexes', array( $this, 'inject_aioseo_sitemap_entry' ) );
+
+                add_action( 'save_post', array( $this, 'invalidate_sitemap_cache' ), 20, 0 );
+                add_action( 'delete_post', array( $this, 'invalidate_sitemap_cache' ), 20, 0 );
+                add_action( 'created_term', array( $this, 'invalidate_sitemap_cache' ), 20, 0 );
+                add_action( 'edited_term', array( $this, 'invalidate_sitemap_cache' ), 20, 0 );
+                add_action( 'delete_term', array( $this, 'invalidate_sitemap_cache' ), 20, 0 );
+                add_action( 'fpml_post_jobs_enqueued', array( $this, 'invalidate_sitemap_cache' ), 90, 0 );
+        }
+
+        /**
+         * Ensure key SEO meta fields are always part of the translation whitelist.
+         *
+         * @since 0.2.0
+         *
+         * @param array $keys Current whitelist.
+         *
+         * @return array
+         */
+        public function register_seo_meta_keys( $keys ) {
+                $keys = is_array( $keys ) ? $keys : array();
+
+                $defaults = array(
+                        '_yoast_wpseo_title',
+                        '_yoast_wpseo_metadesc',
+                        '_yoast_wpseo_opengraph-title',
+                        '_yoast_wpseo_opengraph-description',
+                        '_yoast_wpseo_twitter-title',
+                        '_yoast_wpseo_twitter-description',
+                        '_yoast_wpseo_canonical',
+                        'rank_math_title',
+                        'rank_math_description',
+                        'rank_math_facebook_title',
+                        'rank_math_facebook_description',
+                        'rank_math_twitter_title',
+                        'rank_math_twitter_description',
+                        'rank_math_canonical_url',
+                        '_aioseo_title',
+                        '_aioseo_description',
+                        '_aioseo_og_title',
+                        '_aioseo_og_description',
+                        '_aioseo_twitter_title',
+                        '_aioseo_twitter_description',
+                        '_aioseo_canonical_url',
+                );
+
+                $merged = array_merge( $keys, $defaults );
+                $merged = array_map( 'sanitize_key', $merged );
+
+                return array_values( array_unique( array_filter( $merged ) ) );
+        }
+
+        /**
+         * Enqueue slug translation jobs when requested.
+         *
+         * @since 0.2.0
+         *
+         * @param WP_Post $source_post Italian post.
+         * @param WP_Post $target_post English post.
+         * @param bool    $update      Whether this is an update operation.
+         *
+         * @return void
+         */
+        public function maybe_enqueue_slug_job( $source_post, $target_post, $update ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+                if ( ! $this->settings->get( 'translate_slugs', false ) ) {
+                        return;
+                }
+
+                if ( ! ( $source_post instanceof WP_Post ) || ! ( $target_post instanceof WP_Post ) ) {
+                        return;
+                }
+
+                if ( 'attachment' === $source_post->post_type ) {
+                        return;
+                }
+
+                $slug = (string) $source_post->post_name;
+
+                if ( '' === $slug ) {
+                        $slug = sanitize_title( $source_post->post_title );
+                }
+
+                if ( '' === $slug ) {
+                        return;
+                }
+
+                $hash = md5( $slug );
+
+                $this->queue->enqueue( 'post', $source_post->ID, 'slug', $hash );
+                update_post_meta( $target_post->ID, '_fpml_status_slug', 'needs_update' );
+        }
+
+        /**
+         * Render canonical, hreflang and robots hints into the head.
+         *
+         * @since 0.2.0
+         *
+         * @return void
+         */
+        public function render_head_tags() {
+                if ( is_admin() ) {
+                        return;
+                }
+
+                $canonical = $this->get_canonical_url();
+
+                if ( $canonical && ! $this->is_seo_plugin_active() ) {
+                        echo '<link rel="canonical" href="' . esc_url( $canonical ) . '" />' . "\n"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                }
+
+                $hreflangs = $this->get_hreflang_links();
+
+                foreach ( $hreflangs as $link ) {
+                        echo '<link rel="alternate" hreflang="' . esc_attr( $link['lang'] ) . '" href="' . esc_url( $link['url'] ) . '" />' . "\n"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                }
+
+                if ( $this->should_noindex() && ! $this->is_seo_plugin_active() ) {
+                        echo '<meta name="robots" content="noindex,nofollow" />' . "\n"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                }
+        }
+
+        /**
+         * Filter canonical URL emitted by compatible SEO plugins.
+         *
+         * @since 0.2.0
+         *
+         * @param string $canonical Current canonical URL.
+         *
+         * @return string
+         */
+        public function filter_canonical_url( $canonical ) {
+                $custom = $this->get_canonical_url();
+
+                if ( $custom ) {
+                        return $custom;
+                }
+
+                return $canonical;
+        }
+
+        /**
+         * Override robots directives when EN pages are marked as noindex.
+         *
+         * @since 0.2.0
+         *
+         * @param string $directives Robots directives string.
+         *
+         * @return string
+         */
+        public function filter_robots_directive( $directives ) {
+                if ( ! $this->should_noindex() ) {
+                        return $directives;
+                }
+
+                return 'noindex,nofollow';
+        }
+
+        /**
+         * Adjust Rank Math robots directives.
+         *
+         * @since 0.2.0
+         *
+         * @param mixed $directives Current directives (array|string).
+         *
+         * @return mixed
+         */
+        public function filter_rankmath_robots( $directives ) {
+                if ( ! $this->should_noindex() ) {
+                        return $directives;
+                }
+
+                if ( is_array( $directives ) ) {
+                        return array( 'noindex', 'nofollow' );
+                }
+
+                return 'noindex,nofollow';
+        }
+
+        /**
+         * Handle slug translation saving logic.
+         *
+         * @since 0.2.0
+         *
+         * @param WP_Post $post        English post object.
+         * @param string  $new_value   Raw translated phrase.
+         *
+         * @return void
+         */
+        public function handle_slug_translation( $post, $new_value ) {
+                if ( ! ( $post instanceof WP_Post ) ) {
+                        return;
+                }
+
+                $translated = sanitize_text_field( (string) $new_value );
+
+                if ( '' === $translated ) {
+                        return;
+                }
+
+                $slug_candidate = sanitize_title( $translated );
+
+                if ( '' === $slug_candidate ) {
+                        return;
+                }
+
+                $old_slug = (string) $post->post_name;
+
+                if ( $old_slug === $slug_candidate ) {
+                        update_post_meta( $post->ID, '_fpml_status_slug', 'automatic' );
+                        return;
+                }
+
+                $result = wp_update_post(
+                        array(
+                                'ID'        => $post->ID,
+                                'post_name' => $slug_candidate,
+                        ),
+                        true
+                );
+
+                if ( is_wp_error( $result ) ) {
+                        $this->logger->log(
+                                'error',
+                                sprintf( 'Impossibile aggiornare lo slug inglese per il post #%d: %s', $post->ID, $result->get_error_message() ),
+                                array(
+                                        'post_id' => $post->ID,
+                                        'context' => 'slug',
+                                )
+                        );
+
+                        return;
+                }
+
+                update_post_meta( $post->ID, '_fpml_status_slug', 'automatic' );
+
+                if ( $this->settings->get( 'slug_redirect', false ) && '' !== $old_slug ) {
+                        $this->register_slug_redirect( $post->ID, $old_slug, $slug_candidate );
+                }
+        }
+
+        /**
+         * Persist redirect mapping for legacy English slugs.
+         *
+         * @since 0.2.0
+         *
+         * @param int    $post_id   Post ID.
+         * @param string $old_slug  Previous slug.
+         * @param string $new_slug  New slug.
+         *
+         * @return void
+         */
+        protected function register_slug_redirect( $post_id, $old_slug, $new_slug ) {
+                $post_id  = absint( $post_id );
+                $old_slug = sanitize_title( $old_slug );
+                $new_slug = sanitize_title( $new_slug );
+
+                if ( $post_id <= 0 || '' === $old_slug || '' === $new_slug || $old_slug === $new_slug ) {
+                        return;
+                }
+
+                $redirects = get_option( 'fpml_slug_redirects', array() );
+
+                if ( ! is_array( $redirects ) ) {
+                        $redirects = array();
+                }
+
+                $redirects = array_values( array_filter( $redirects, function( $entry ) use ( $post_id, $old_slug ) {
+                        if ( ! is_array( $entry ) || ! isset( $entry['post_id'], $entry['old_slug'] ) ) {
+                                return false;
+                        }
+
+                        if ( (int) $entry['post_id'] === $post_id && sanitize_title( $entry['old_slug'] ) === $old_slug ) {
+                                return false;
+                        }
+
+                        return true;
+                } ) );
+
+                $redirects[] = array(
+                        'post_id'   => $post_id,
+                        'old_slug'  => $old_slug,
+                        'new_slug'  => $new_slug,
+                        'lang'      => 'en',
+                        'timestamp' => time(),
+                );
+
+                if ( count( $redirects ) > 50 ) {
+                        $redirects = array_slice( $redirects, -50 );
+                }
+
+                update_option( 'fpml_slug_redirects', $redirects, false );
+
+                $this->logger->log(
+                        'info',
+                        sprintf( 'Registrato redirect 301 da %1$s a %2$s per il post #%3$d.', $old_slug, $new_slug, $post_id ),
+                        array(
+                                'post_id' => $post_id,
+                                'context' => 'slug_redirect',
+                        )
+                );
+        }
+
+        /**
+         * Redirect legacy English slugs when requested.
+         *
+         * @since 0.2.0
+         *
+         * @return void
+         */
+        public function handle_legacy_slug_redirects() {
+                if ( is_admin() || ! is_404() || ! $this->settings->get( 'slug_redirect', false ) ) {
+                        return;
+                }
+
+                $slug = $this->get_request_slug();
+
+                if ( '' === $slug ) {
+                        return;
+                }
+
+                $redirects = get_option( 'fpml_slug_redirects', array() );
+
+                if ( empty( $redirects ) || ! is_array( $redirects ) ) {
+                        return;
+                }
+
+                foreach ( $redirects as $entry ) {
+                        if ( ! is_array( $entry ) || empty( $entry['old_slug'] ) || $entry['old_slug'] !== $slug ) {
+                                continue;
+                        }
+
+                        if ( ! empty( $entry['lang'] ) && 'en' !== $entry['lang'] ) {
+                                continue;
+                        }
+
+                        $post_id = isset( $entry['post_id'] ) ? (int) $entry['post_id'] : 0;
+
+                        if ( $post_id <= 0 ) {
+                                continue;
+                        }
+
+                        $post = get_post( $post_id );
+
+                        if ( ! $post instanceof WP_Post || 'publish' !== $post->post_status ) {
+                                continue;
+                        }
+
+                        $target = get_permalink( $post );
+
+                        if ( empty( $target ) ) {
+                                continue;
+                        }
+
+                        wp_safe_redirect( $target, 301 );
+                        exit;
+                }
+        }
+
+        /**
+         * Determine whether EN pages should be noindex.
+         *
+         * @since 0.2.0
+         *
+         * @return bool
+         */
+        protected function should_noindex() {
+                return (bool) ( $this->settings->get( 'noindex_en', false ) && FPML_Language::TARGET === $this->language->get_current_language() );
+        }
+
+        /**
+         * Check if a major SEO plugin is active to avoid duplicate tags.
+         *
+         * @since 0.2.0
+         *
+         * @return bool
+         */
+        protected function is_seo_plugin_active() {
+                return ( defined( 'WPSEO_VERSION' ) || defined( 'RANK_MATH_VERSION' ) || defined( 'AIOSEO_VERSION' ) || class_exists( '\\AIOSEO\\Plugin\\Common\\Main' ) );
+        }
+
+        /**
+         * Compute canonical URL for the current request.
+         *
+         * @since 0.2.0
+         *
+         * @return string
+         */
+        protected function get_canonical_url() {
+                if ( is_front_page() || is_home() ) {
+                        if ( FPML_Language::TARGET === $this->language->get_current_language() ) {
+                                return $this->language->get_url_for_language( FPML_Language::TARGET );
+                        }
+
+                        return home_url( '/' );
+                }
+
+                if ( is_singular() ) {
+                        $object = get_queried_object();
+
+                        if ( $object instanceof WP_Post ) {
+                                return get_permalink( $object );
+                        }
+                }
+
+                if ( is_tax() || is_category() || is_tag() ) {
+                        $term = get_queried_object();
+
+                        if ( $term instanceof WP_Term ) {
+                                $link = get_term_link( $term );
+
+                                if ( ! is_wp_error( $link ) ) {
+                                        return $link;
+                                }
+                        }
+                }
+
+                return '';
+        }
+
+        /**
+         * Build hreflang associations for the current object.
+         *
+         * @since 0.2.0
+         *
+         * @return array
+         */
+        protected function get_hreflang_links() {
+                $links = array();
+
+                if ( is_front_page() || is_home() ) {
+                        $italian = home_url( '/' );
+                        $english = $this->language->get_url_for_language( FPML_Language::TARGET );
+
+                        if ( $italian ) {
+                                $links[] = array(
+                                        'lang' => 'it-IT',
+                                        'url'  => $italian,
+                                );
+                        }
+
+                        if ( $english ) {
+                                $links[] = array(
+                                        'lang' => 'en-US',
+                                        'url'  => $english,
+                                );
+                        }
+
+                        if ( ! empty( $links ) && apply_filters( 'fpml_output_xdefault', true ) ) {
+                                $links[] = array(
+                                        'lang' => 'x-default',
+                                        'url'  => $english ? $english : $italian,
+                                );
+                        }
+
+                        return $links;
+                }
+
+                if ( is_singular() ) {
+                        $object = get_queried_object();
+
+                        if ( ! $object instanceof WP_Post ) {
+                                return $links;
+                        }
+
+                        if ( get_post_meta( $object->ID, '_fpml_is_translation', true ) ) {
+                                $source_id = (int) get_post_meta( $object->ID, '_fpml_pair_source_id', true );
+                                $italian   = $source_id ? get_permalink( $source_id ) : '';
+                                $english   = get_permalink( $object );
+                        } else {
+                                $target_id = (int) get_post_meta( $object->ID, '_fpml_pair_id', true );
+                                $italian   = get_permalink( $object );
+                                $english   = $target_id ? get_permalink( $target_id ) : '';
+                        }
+
+                        if ( $italian ) {
+                                $links[] = array(
+                                        'lang' => 'it-IT',
+                                        'url'  => $italian,
+                                );
+                        }
+
+                        if ( $english ) {
+                                $links[] = array(
+                                        'lang' => 'en-US',
+                                        'url'  => $english,
+                                );
+                        }
+
+                        return $links;
+                }
+
+                if ( is_tax() || is_category() || is_tag() ) {
+                        $term = get_queried_object();
+
+                        if ( ! $term instanceof WP_Term ) {
+                                return $links;
+                        }
+
+                        if ( get_term_meta( $term->term_id, '_fpml_is_translation', true ) ) {
+                                $source_id = (int) get_term_meta( $term->term_id, '_fpml_pair_source_id', true );
+                                $source    = $source_id ? get_term( $source_id ) : null;
+                                $target    = $term;
+                        } else {
+                                $target_id = (int) get_term_meta( $term->term_id, '_fpml_pair_id', true );
+                                $source    = $term;
+                                $target    = $target_id ? get_term( $target_id ) : null;
+                        }
+
+                        if ( $source instanceof WP_Term ) {
+                                $italian_link = get_term_link( $source );
+
+                                if ( ! is_wp_error( $italian_link ) ) {
+                                        $links[] = array(
+                                                'lang' => 'it-IT',
+                                                'url'  => $italian_link,
+                                        );
+                                }
+                        }
+
+                        if ( $target instanceof WP_Term ) {
+                                $english_link = get_term_link( $target );
+
+                                if ( ! is_wp_error( $english_link ) ) {
+                                        $links[] = array(
+                                                'lang' => 'en-US',
+                                                'url'  => $english_link,
+                                        );
+                                }
+                        }
+                }
+
+                return $links;
+        }
+
+        /**
+         * Maybe render the English sitemap when requested.
+         *
+         * @since 0.2.0
+         *
+         * @return void
+         */
+        public function maybe_render_sitemap() {
+                if ( is_admin() ) {
+                        return;
+                }
+
+                $requested = get_query_var( 'fpml_sitemap' );
+
+                if ( empty( $requested ) && isset( $_GET['fpml_sitemap'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+                        $requested = sanitize_key( wp_unslash( $_GET['fpml_sitemap'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+                } else {
+                        $requested = sanitize_key( (string) $requested );
+                }
+
+                if ( 'en' !== $requested ) {
+                        return;
+                }
+
+                $charset = get_bloginfo( 'charset' );
+
+                if ( ! $charset ) {
+                        $charset = 'UTF-8';
+                }
+
+                $charset = preg_replace( '/[^a-zA-Z0-9\-]/', '', $charset );
+
+                if ( '' === $charset ) {
+                        $charset = 'UTF-8';
+                }
+
+                $cache_key = $this->get_sitemap_cache_key();
+                $xml       = get_transient( $cache_key );
+
+                if ( ! is_string( $xml ) || '' === $xml ) {
+                        $xml = $this->build_sitemap_xml();
+                        set_transient( $cache_key, $xml, HOUR_IN_SECONDS );
+                }
+
+                nocache_headers();
+                status_header( 200 );
+                header( 'Content-Type: application/xml; charset=' . $charset );
+                echo $xml; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                exit;
+        }
+
+        /**
+         * Build sitemap XML markup for English content.
+         *
+         * @since 0.2.0
+         *
+         * @return string
+         */
+        protected function build_sitemap_xml() {
+                $entries = $this->collect_sitemap_entries();
+                $charset = get_bloginfo( 'charset' );
+
+                if ( ! $charset ) {
+                        $charset = 'UTF-8';
+                }
+
+                $charset = preg_replace( '/[^a-zA-Z0-9\-]/', '', $charset );
+
+                if ( '' === $charset ) {
+                        $charset = 'UTF-8';
+                }
+
+                $lines   = array();
+                $lines[] = '<?xml version="1.0" encoding="' . esc_html( $charset ) . '"?>';
+                $lines[] = '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">';
+
+                foreach ( $entries as $entry ) {
+                        if ( empty( $entry['loc'] ) ) {
+                                continue;
+                        }
+
+                        $lines[] = '\t<url>';
+                        $lines[] = '\t\t<loc>' . esc_url( $entry['loc'] ) . '</loc>';
+
+                        if ( ! empty( $entry['lastmod'] ) ) {
+                                $lines[] = '\t\t<lastmod>' . esc_html( gmdate( 'c', (int) $entry['lastmod'] ) ) . '</lastmod>';
+                        }
+
+                        $lines[] = '\t</url>';
+                }
+
+                $lines[] = '</urlset>';
+
+                return implode( "\n", $lines );
+        }
+
+        /**
+         * Gather sitemap entries for English content.
+         *
+         * @since 0.2.0
+         *
+         * @return array
+         */
+        protected function collect_sitemap_entries() {
+                $entries = array();
+
+                $home = $this->language->get_url_for_language( FPML_Language::TARGET );
+
+                if ( $home ) {
+                        $entries[] = array(
+                                'loc'     => $home,
+                                'lastmod' => $this->get_front_page_lastmod(),
+                        );
+                }
+
+                $post_types  = $this->get_sitemap_post_types();
+                $post_status = array( 'publish' );
+
+                if ( in_array( 'attachment', $post_types, true ) ) {
+                        $post_status[] = 'inherit';
+                }
+
+                if ( ! empty( $post_types ) ) {
+                        $args = array(
+                                'post_type'      => $post_types,
+                                'post_status'    => $post_status,
+                                'posts_per_page' => 200,
+                                'paged'          => 1,
+                                'orderby'        => 'ID',
+                                'order'          => 'ASC',
+                                'no_found_rows'  => true,
+                                'fields'         => 'ids',
+                                'meta_query'     => array(
+                                        array(
+                                                'key'   => '_fpml_is_translation',
+                                                'value' => '1',
+                                        ),
+                                ),
+                        );
+
+                        do {
+                                $query = new WP_Query( $args );
+
+                                if ( empty( $query->posts ) ) {
+                                        break;
+                                }
+
+                                foreach ( $query->posts as $post_id ) {
+                                        $post = get_post( (int) $post_id );
+
+                                        if ( ! $post instanceof WP_Post ) {
+                                                continue;
+                                        }
+
+                                        $url = get_permalink( $post );
+
+                                        if ( ! $url ) {
+                                                continue;
+                                        }
+
+                                        $entries[] = array(
+                                                'loc'     => $url,
+                                                'lastmod' => (int) get_post_modified_time( 'U', true, $post ),
+                                        );
+                                }
+
+                                $args['paged']++;
+                        } while ( count( $query->posts ) === $args['posts_per_page'] );
+                }
+
+                $taxonomies = $this->get_sitemap_taxonomies();
+
+                if ( ! empty( $taxonomies ) ) {
+                        $term_query = new WP_Term_Query(
+                                array(
+                                        'taxonomy'   => $taxonomies,
+                                        'hide_empty' => false,
+                                        'meta_query' => array(
+                                                array(
+                                                        'key'   => '_fpml_is_translation',
+                                                        'value' => '1',
+                                                ),
+                                        ),
+                                )
+                        );
+
+                        if ( ! is_wp_error( $term_query ) && ! empty( $term_query->terms ) ) {
+                                foreach ( $term_query->terms as $term ) {
+                                        if ( ! $term instanceof WP_Term ) {
+                                                continue;
+                                        }
+
+                                        $link = get_term_link( $term );
+
+                                        if ( is_wp_error( $link ) || ! $link ) {
+                                                continue;
+                                        }
+
+                                        $entries[] = array(
+                                                'loc'     => $link,
+                                                'lastmod' => 0,
+                                        );
+                                }
+                        }
+                }
+
+                /**
+                 * Allow customization of sitemap entries.
+                 *
+                 * @since 0.2.0
+                 *
+                 * @param array $entries Sitemap entries array.
+                 */
+                return apply_filters( 'fpml_sitemap_entries', $entries );
+        }
+
+        /**
+         * Retrieve the cache key for the sitemap payload.
+         *
+         * @since 0.2.0
+         *
+         * @return string
+         */
+        protected function get_sitemap_cache_key() {
+                return 'fpml_sitemap_en_cache';
+        }
+
+        /**
+         * Resolve post types included in the English sitemap.
+         *
+         * @since 0.2.0
+         *
+         * @return array
+         */
+        protected function get_sitemap_post_types() {
+                $post_types = get_post_types(
+                        array(
+                                'public' => true,
+                        ),
+                        'names'
+                );
+
+                if ( ! in_array( 'attachment', $post_types, true ) ) {
+                        $post_types[] = 'attachment';
+                }
+
+                $post_types = apply_filters( 'fpml_sitemap_post_types', $post_types );
+
+                return array_filter( array_map( 'sanitize_key', (array) $post_types ) );
+        }
+
+        /**
+         * Resolve taxonomies included in the English sitemap.
+         *
+         * @since 0.2.0
+         *
+         * @return array
+         */
+        protected function get_sitemap_taxonomies() {
+                $taxonomies = get_taxonomies(
+                        array(
+                                'public' => true,
+                        ),
+                        'names'
+                );
+
+                $taxonomies = apply_filters( 'fpml_sitemap_taxonomies', $taxonomies );
+
+                return array_filter( array_map( 'sanitize_key', (array) $taxonomies ) );
+        }
+
+        /**
+         * Retrieve the last modification timestamp for sitemap indexing.
+         *
+         * @since 0.2.0
+         *
+         * @return int
+         */
+        protected function get_sitemap_lastmod_timestamp() {
+                $post_types  = $this->get_sitemap_post_types();
+                $post_status = array( 'publish' );
+
+                if ( in_array( 'attachment', $post_types, true ) ) {
+                        $post_status[] = 'inherit';
+                }
+
+                $timestamp = 0;
+
+                if ( ! empty( $post_types ) ) {
+                        $latest = new WP_Query(
+                                array(
+                                        'post_type'      => $post_types,
+                                        'post_status'    => $post_status,
+                                        'posts_per_page' => 1,
+                                        'orderby'        => 'modified',
+                                        'order'          => 'DESC',
+                                        'no_found_rows'  => true,
+                                        'fields'         => 'ids',
+                                        'meta_query'     => array(
+                                                array(
+                                                        'key'   => '_fpml_is_translation',
+                                                        'value' => '1',
+                                                ),
+                                        ),
+                                )
+                        );
+
+                        if ( ! empty( $latest->posts ) ) {
+                                $post      = get_post( (int) $latest->posts[0] );
+                                $timestamp = $post instanceof WP_Post ? (int) get_post_modified_time( 'U', true, $post ) : 0;
+                        }
+                }
+
+                $front_timestamp = $this->get_front_page_lastmod();
+
+                if ( $front_timestamp > $timestamp ) {
+                        $timestamp = $front_timestamp;
+                }
+
+                if ( $timestamp <= 0 ) {
+                        $timestamp = time();
+                }
+
+                return $timestamp;
+        }
+
+        /**
+         * Attempt to retrieve the English front page last modification.
+         *
+         * @since 0.2.0
+         *
+         * @return int
+         */
+        protected function get_front_page_lastmod() {
+                $front_id = (int) get_option( 'page_on_front' );
+
+                if ( $front_id <= 0 ) {
+                        return 0;
+                }
+
+                $english_id = (int) get_post_meta( $front_id, '_fpml_pair_id', true );
+
+                if ( $english_id > 0 ) {
+                        $front_id = $english_id;
+                }
+
+                $post = get_post( $front_id );
+
+                if ( ! $post instanceof WP_Post ) {
+                        return 0;
+                }
+
+                return (int) get_post_modified_time( 'U', true, $post );
+        }
+
+        /**
+         * Return sitemap absolute URL.
+         *
+         * @since 0.2.0
+         *
+         * @return string
+         */
+        protected function get_sitemap_url() {
+                return home_url( '/sitemap-en.xml' );
+        }
+
+        /**
+         * Inject English sitemap entry into Yoast SEO sitemap index.
+         *
+         * @since 0.2.0
+         *
+         * @param string $content Sitemap XML.
+         *
+         * @return string
+         */
+        public function inject_wpseo_sitemap_entry( $content ) {
+                $content = (string) $content;
+                $url     = $this->get_sitemap_url();
+
+                if ( '' === $url || false === strpos( $content, '<sitemapindex' ) ) {
+                        return $content;
+                }
+
+                if ( false !== strpos( $content, $url ) ) {
+                        return $content;
+                }
+
+                $lastmod = esc_html( gmdate( 'c', $this->get_sitemap_lastmod_timestamp() ) );
+                $entry   = '<sitemap><loc>' . esc_url( $url ) . '</loc><lastmod>' . $lastmod . '</lastmod></sitemap>';
+
+                return str_replace( '</sitemapindex>', $entry . '</sitemapindex>', $content );
+        }
+
+        /**
+         * Inject English sitemap entry into Rank Math sitemap index.
+         *
+         * @since 0.2.0
+         *
+         * @param array $entries Sitemap entries.
+         *
+         * @return array
+         */
+        public function inject_rankmath_sitemap_entry( $entries ) {
+                if ( ! is_array( $entries ) ) {
+                        $entries = array();
+                }
+
+                $url = $this->get_sitemap_url();
+
+                if ( '' === $url ) {
+                        return $entries;
+                }
+
+                foreach ( $entries as $entry ) {
+                        if ( ! is_array( $entry ) ) {
+                                continue;
+                        }
+
+                        if ( isset( $entry['loc'] ) && $url === $entry['loc'] ) {
+                                return $entries;
+                        }
+                }
+
+                $entries[] = array(
+                        'loc'     => $url,
+                        'lastmod' => gmdate( 'c', $this->get_sitemap_lastmod_timestamp() ),
+                );
+
+                return $entries;
+        }
+
+        /**
+         * Inject English sitemap entry into AIOSEO sitemap index.
+         *
+         * @since 0.2.0
+         *
+         * @param array $indexes Sitemap index entries.
+         *
+         * @return array
+         */
+        public function inject_aioseo_sitemap_entry( $indexes ) {
+                if ( ! is_array( $indexes ) ) {
+                        $indexes = array();
+                }
+
+                $url = $this->get_sitemap_url();
+
+                if ( '' === $url ) {
+                        return $indexes;
+                }
+
+                foreach ( $indexes as $index ) {
+                        if ( ! is_array( $index ) ) {
+                                continue;
+                        }
+
+                        if ( isset( $index['loc'] ) && $url === $index['loc'] ) {
+                                return $indexes;
+                        }
+                }
+
+                $indexes[] = array(
+                        'loc'     => $url,
+                        'lastmod' => gmdate( 'c', $this->get_sitemap_lastmod_timestamp() ),
+                );
+
+                return $indexes;
+        }
+
+        /**
+         * Clear cached sitemap payload when content changes.
+         *
+         * @since 0.2.0
+         *
+         * @return void
+         */
+        public function invalidate_sitemap_cache() {
+                delete_transient( $this->get_sitemap_cache_key() );
+        }
+
+        /**
+         * Extract the current request slug from the URL.
+         *
+         * @since 0.2.0
+         *
+         * @return string
+         */
+        protected function get_request_slug() {
+                $uri = isset( $_SERVER['REQUEST_URI'] ) ? wp_unslash( $_SERVER['REQUEST_URI'] ) : ''; // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER
+
+                if ( '' === $uri ) {
+                        return '';
+                }
+
+                $path = (string) parse_url( $uri, PHP_URL_PATH );
+
+                if ( '' === $path ) {
+                        return '';
+                }
+
+                $home_path = (string) parse_url( home_url( '/' ), PHP_URL_PATH );
+
+                if ( $home_path && 0 === strpos( $path, $home_path ) ) {
+                        $path = substr( $path, strlen( $home_path ) );
+                }
+
+                $path = trim( $path, '/' );
+
+                if ( '' === $path ) {
+                        return '';
+                }
+
+                $parts = explode( '/', $path );
+                $slug  = end( $parts );
+
+                return sanitize_title( $slug );
+        }
+}

--- a/fp-multilanguage/includes/class-strings-override.php
+++ b/fp-multilanguage/includes/class-strings-override.php
@@ -1,0 +1,382 @@
+<?php
+/**
+ * Manage manual overrides for scanned strings.
+ *
+ * @package FP_Multilanguage
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+        exit;
+}
+
+/**
+ * Provide storage utilities and runtime filters for string overrides.
+ *
+ * @since 0.2.0
+ */
+class FPML_Strings_Override {
+        /**
+         * Option storing overrides.
+         */
+        const OPTION_KEY = 'fpml_strings_overrides';
+
+        /**
+         * Singleton instance.
+         *
+         * @var FPML_Strings_Override|null
+         */
+        protected static $instance = null;
+
+        /**
+         * Cached overrides list.
+         *
+         * @var array
+         */
+        protected $overrides = array();
+
+        /**
+         * Constructor.
+         */
+        protected function __construct() {
+                $this->overrides = $this->load_overrides();
+                $this->register_filters();
+        }
+
+        /**
+         * Retrieve singleton instance.
+         *
+         * @since 0.2.0
+         *
+         * @return FPML_Strings_Override
+         */
+        public static function instance() {
+                if ( null === self::$instance ) {
+                        self::$instance = new self();
+                }
+
+                return self::$instance;
+        }
+
+        /**
+         * Load overrides from storage.
+         *
+         * @since 0.2.0
+         *
+         * @return array
+         */
+        protected function load_overrides() {
+                $stored = get_option( self::OPTION_KEY, array() );
+
+                if ( ! is_array( $stored ) ) {
+                        $stored = array();
+                }
+
+                return $stored;
+        }
+
+        /**
+         * Persist overrides list.
+         *
+         * @since 0.2.0
+         *
+         * @param array $overrides Overrides to persist.
+         *
+         * @return void
+         */
+        protected function save_overrides( $overrides ) {
+                update_option( self::OPTION_KEY, $overrides );
+                $this->overrides = $overrides;
+        }
+
+        /**
+         * Register runtime filters so the overrides apply to gettext calls.
+         *
+         * @since 0.2.0
+         *
+         * @return void
+         */
+        protected function register_filters() {
+                add_filter( 'gettext', array( $this, 'filter_gettext' ), 10, 3 );
+                add_filter( 'ngettext', array( $this, 'filter_ngettext' ), 10, 5 );
+        }
+
+        /**
+         * Retrieve overrides.
+         *
+         * @since 0.2.0
+         *
+         * @return array
+         */
+        public function get_overrides() {
+                return $this->overrides;
+        }
+
+        /**
+         * Update override translations.
+         *
+         * @since 0.2.0
+         *
+         * @param array $payload Overrides payload keyed by hash.
+         *
+         * @return void
+         */
+        public function update_overrides( $payload ) {
+                $payload = is_array( $payload ) ? $payload : array();
+
+                foreach ( $payload as $hash => $row ) {
+                        if ( ! isset( $this->overrides[ $hash ] ) ) {
+                                continue;
+                        }
+
+                        if ( isset( $row['delete'] ) && $row['delete'] ) {
+                                unset( $this->overrides[ $hash ] );
+                                continue;
+                        }
+
+                        $target = isset( $row['target'] ) ? sanitize_text_field( $row['target'] ) : '';
+                        $context = isset( $row['context'] ) ? sanitize_text_field( $row['context'] ) : $this->overrides[ $hash ]['context'];
+
+                        $this->overrides[ $hash ]['target']     = $target;
+                        $this->overrides[ $hash ]['context']    = $context;
+                        $this->overrides[ $hash ]['updated_at'] = current_time( 'timestamp' );
+                }
+
+                $this->save_overrides( $this->overrides );
+        }
+
+        /**
+         * Add a new override.
+         *
+         * @since 0.2.0
+         *
+         * @param string $source  Original string.
+         * @param string $target  Override translation.
+         * @param string $context Optional context.
+         *
+         * @return void
+         */
+        public function add_override( $source, $target, $context = '' ) {
+                $source  = sanitize_text_field( $source );
+                $target  = sanitize_text_field( $target );
+                $context = sanitize_text_field( $context );
+
+                if ( '' === $source || '' === $target ) {
+                        return;
+                }
+
+                $hash                        = md5( wp_json_encode( array( $source, $context ) ) );
+                $this->overrides[ $hash ]     = array(
+                        'source'     => $source,
+                        'target'     => $target,
+                        'context'    => $context,
+                        'updated_at' => current_time( 'timestamp' ),
+                );
+                $this->save_overrides( $this->overrides );
+        }
+
+        /**
+         * Delete overrides.
+         *
+         * @since 0.2.0
+         *
+         * @param array $hashes Hashes to remove.
+         *
+         * @return void
+         */
+        public function delete_overrides( $hashes ) {
+                if ( empty( $hashes ) ) {
+                        return;
+                }
+
+                foreach ( $hashes as $hash ) {
+                        unset( $this->overrides[ $hash ] );
+                }
+
+                $this->save_overrides( $this->overrides );
+        }
+
+        /**
+         * Export overrides as JSON string.
+         *
+         * @since 0.2.0
+         *
+         * @return string
+         */
+        public function export_json() {
+                return wp_json_encode( array_values( $this->overrides ) );
+        }
+
+        /**
+         * Export overrides as CSV string.
+         *
+         * @since 0.2.0
+         *
+         * @return string
+         */
+        public function export_csv() {
+                $rows = array();
+                $rows[] = array( 'source', 'target', 'context' );
+
+                foreach ( $this->overrides as $row ) {
+                        $rows[] = array( $row['source'], $row['target'], $row['context'] );
+                }
+
+                $buffer = fopen( 'php://temp', 'w+' );
+
+                foreach ( $rows as $row ) {
+                        fputcsv( $buffer, $row );
+                }
+
+                rewind( $buffer );
+                $csv = stream_get_contents( $buffer );
+                fclose( $buffer );
+
+                return $csv;
+        }
+
+        /**
+         * Import overrides from JSON payload.
+         *
+         * @since 0.2.0
+         *
+         * @param string $json JSON payload.
+         *
+         * @return int Number of imported rows.
+         */
+        public function import_json( $json ) {
+                $decoded = json_decode( $json, true );
+
+                if ( ! is_array( $decoded ) ) {
+                        return 0;
+                }
+
+                $imported = 0;
+
+                foreach ( $decoded as $row ) {
+                        if ( empty( $row['source'] ) || empty( $row['target'] ) ) {
+                                continue;
+                        }
+
+                        $this->add_override( $row['source'], $row['target'], isset( $row['context'] ) ? $row['context'] : '' );
+                        $imported++;
+                }
+
+                return $imported;
+        }
+
+        /**
+         * Import overrides from CSV payload.
+         *
+         * @since 0.2.0
+         *
+         * @param string $csv CSV payload.
+         *
+         * @return int Number of imported rows.
+         */
+        public function import_csv( $csv ) {
+                $lines = explode( "\n", $csv );
+
+                if ( empty( $lines ) ) {
+                        return 0;
+                }
+
+                $imported = 0;
+                $header   = true;
+
+                foreach ( $lines as $line ) {
+                        $line = trim( $line );
+
+                        if ( '' === $line ) {
+                                continue;
+                        }
+
+                        $columns = str_getcsv( $line );
+
+                        if ( $header ) {
+                                $header = false;
+                                continue;
+                        }
+
+                        $source  = isset( $columns[0] ) ? $columns[0] : '';
+                        $target  = isset( $columns[1] ) ? $columns[1] : '';
+                        $context = isset( $columns[2] ) ? $columns[2] : '';
+
+                        if ( '' === $source || '' === $target ) {
+                                continue;
+                        }
+
+                        $this->add_override( $source, $target, $context );
+                        $imported++;
+                }
+
+                return $imported;
+        }
+
+        /**
+         * Apply overrides to gettext calls.
+         *
+         * @since 0.2.0
+         *
+         * @param string $translation Current translation.
+         * @param string $text        Original text.
+         * @param string $domain      Text domain.
+         *
+         * @return string
+         */
+        public function filter_gettext( $translation, $text, $domain ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+                if ( empty( $this->overrides ) ) {
+                        return $translation;
+                }
+
+                $language = FPML_Language::instance();
+
+                if ( $language && method_exists( $language, 'get_current_language' ) && FPML_Language::TARGET !== $language->get_current_language() ) {
+                        return $translation;
+                }
+
+                foreach ( $this->overrides as $row ) {
+                        if ( $row['source'] === $text ) {
+                                return $row['target'];
+                        }
+                }
+
+                return $translation;
+        }
+
+        /**
+         * Apply overrides to plural gettext calls.
+         *
+         * @since 0.2.0
+         *
+         * @param string $translation Current translation.
+         * @param string $single      Singular text.
+         * @param string $plural      Plural text.
+         * @param string $number      Current number.
+         * @param string $domain      Text domain.
+         *
+         * @return string
+         */
+        public function filter_ngettext( $translation, $single, $plural, $number, $domain ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+                if ( empty( $this->overrides ) ) {
+                        return $translation;
+                }
+
+                $language = FPML_Language::instance();
+
+                if ( $language && method_exists( $language, 'get_current_language' ) && FPML_Language::TARGET !== $language->get_current_language() ) {
+                        return $translation;
+                }
+
+                foreach ( $this->overrides as $row ) {
+                        if ( 1 === (int) $number && $row['source'] === $single ) {
+                                return $row['target'];
+                        }
+
+                        if ( 1 !== (int) $number && $row['source'] === $plural ) {
+                                return $row['target'];
+                        }
+                }
+
+                return $translation;
+        }
+}

--- a/fp-multilanguage/includes/class-strings-scanner.php
+++ b/fp-multilanguage/includes/class-strings-scanner.php
@@ -1,0 +1,319 @@
+<?php
+/**
+ * Scanner for theme and plugin strings used in translation functions.
+ *
+ * @package FP_Multilanguage
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+        exit;
+}
+
+/**
+ * Build and expose a catalog of strings detected across active code.
+ *
+ * @since 0.2.0
+ */
+class FPML_Strings_Scanner {
+        /**
+         * Option storing catalog data.
+         */
+        const OPTION_KEY = 'fpml_strings_catalog';
+
+        /**
+         * Option storing last scan timestamp.
+         */
+        const OPTION_LAST_SCAN = 'fpml_strings_last_scan';
+
+        /**
+         * Singleton instance.
+         *
+         * @var FPML_Strings_Scanner|null
+         */
+        protected static $instance = null;
+
+        /**
+         * Cached catalog.
+         *
+         * @var array
+         */
+        protected $catalog = array();
+
+        /**
+         * Constructor.
+         */
+        protected function __construct() {
+                $this->catalog = $this->load_catalog();
+        }
+
+        /**
+         * Retrieve singleton instance.
+         *
+         * @since 0.2.0
+         *
+         * @return FPML_Strings_Scanner
+         */
+        public static function instance() {
+                if ( null === self::$instance ) {
+                        self::$instance = new self();
+                }
+
+                return self::$instance;
+        }
+
+        /**
+         * Load catalog from storage.
+         *
+         * @since 0.2.0
+         *
+         * @return array
+         */
+        protected function load_catalog() {
+                $stored = get_option( self::OPTION_KEY, array() );
+
+                if ( ! is_array( $stored ) ) {
+                        $stored = array();
+                }
+
+                return $stored;
+        }
+
+        /**
+         * Persist catalog data.
+         *
+         * @since 0.2.0
+         *
+         * @param array $catalog Catalog entries.
+         *
+         * @return void
+         */
+        protected function save_catalog( $catalog ) {
+                update_option( self::OPTION_KEY, $catalog );
+                $this->catalog = $catalog;
+        }
+
+        /**
+         * Retrieve catalog entries.
+         *
+         * @since 0.2.0
+         *
+         * @return array
+         */
+        public function get_catalog() {
+                return $this->catalog;
+        }
+
+        /**
+         * Retrieve last scan timestamp.
+         *
+         * @since 0.2.0
+         *
+         * @return int
+         */
+        public function get_last_scan_time() {
+                return (int) get_option( self::OPTION_LAST_SCAN, 0 );
+        }
+
+        /**
+         * Run a scan of active theme and plugins.
+         *
+         * @since 0.2.0
+         *
+         * @return int Number of unique strings detected.
+         */
+        public function scan() {
+                $targets = $this->get_scan_targets();
+
+                if ( empty( $targets ) ) {
+                        $this->save_catalog( array() );
+                        update_option( self::OPTION_LAST_SCAN, time() );
+                        return 0;
+                }
+
+                $catalog = array();
+
+                foreach ( $targets as $path ) {
+                        $iterator = new RecursiveIteratorIterator(
+                                new RecursiveDirectoryIterator( $path, FilesystemIterator::SKIP_DOTS ),
+                                RecursiveIteratorIterator::SELF_FIRST
+                        );
+
+                        foreach ( $iterator as $file ) {
+                                if ( $file->isDir() ) {
+                                        continue;
+                                }
+
+                                if ( 'php' !== strtolower( $file->getExtension() ) ) {
+                                        continue;
+                                }
+
+                                $this->scan_file( $file->getPathname(), $catalog );
+                        }
+                }
+
+                $this->save_catalog( $catalog );
+                update_option( self::OPTION_LAST_SCAN, time() );
+
+                return count( $catalog );
+        }
+
+        /**
+         * Build list of directories to scan.
+         *
+         * @since 0.2.0
+         *
+         * @return array
+         */
+        protected function get_scan_targets() {
+                $targets = array();
+
+                $theme = get_stylesheet_directory();
+                if ( $theme && is_dir( $theme ) ) {
+                        $targets[] = $theme;
+                }
+
+                $parent_theme = get_template_directory();
+                if ( $parent_theme && is_dir( $parent_theme ) ) {
+                        $targets[] = $parent_theme;
+                }
+
+                $plugins = (array) get_option( 'active_plugins', array() );
+
+                foreach ( $plugins as $plugin_file ) {
+                        $plugin_path = WP_PLUGIN_DIR . '/' . dirname( $plugin_file );
+
+                        if ( is_dir( $plugin_path ) ) {
+                                $targets[] = $plugin_path;
+                        }
+                }
+
+                $targets = array_unique( array_filter( $targets ) );
+
+                /**
+                 * Allow filtering the list of scanned directories.
+                 *
+                 * @since 0.2.0
+                 *
+                 * @param array $targets Directories to scan.
+                 */
+                return apply_filters( 'fpml_strings_scan_targets', $targets );
+        }
+
+        /**
+         * Scan a single PHP file for translation calls.
+         *
+         * @since 0.2.0
+         *
+         * @param string $file_path File path.
+         * @param array  $catalog   Reference to catalog.
+         *
+         * @return void
+         */
+        protected function scan_file( $file_path, array &$catalog ) {
+                $content = file_get_contents( $file_path );
+
+                if ( false === $content ) {
+                        return;
+                }
+
+                $pattern = "/(?P<function>__|_e|esc_html__|esc_attr__|_x|_ex)\\s*\\(\\s*(?P<quote>['\"])" .
+                        "(?P<string>(?:\\\\.|(?!\\1).)+)\\1\\s*(?:,\\s*(?P<context_quote>['\"])" .
+                        "(?P<context>(?:\\\\.|(?!\\4).)+)\\4)?/Uu";
+
+                if ( ! preg_match_all( $pattern, $content, $matches, PREG_SET_ORDER | PREG_OFFSET_CAPTURE ) ) {
+                        return;
+                }
+
+                $rel_path = $this->make_relative_path( $file_path );
+
+                foreach ( $matches as $match ) {
+                        $original = stripcslashes( $match['string'][0] );
+                        $context  = isset( $match['context'][0] ) ? stripcslashes( $match['context'][0] ) : '';
+                        $domain   = $this->extract_text_domain( $content, $match[0][1] + strlen( $match[0][0] ) );
+                        $hash     = md5( wp_json_encode( array( $original, $domain, $context ) ) );
+
+                        if ( ! isset( $catalog[ $hash ] ) ) {
+                                $catalog[ $hash ] = array(
+                                        'original'    => $original,
+                                        'domain'      => $domain,
+                                        'context'     => $context,
+                                        'occurrences' => 0,
+                                        'files'       => array(),
+                                        'last_found'  => current_time( 'timestamp' ),
+                                );
+                        }
+
+                        $line = $this->detect_line_number( $content, $match[0][1] );
+
+                        $catalog[ $hash ]['occurrences']++;
+                        $catalog[ $hash ]['files'][] = array(
+                                'file' => $rel_path,
+                                'line' => $line,
+                        );
+                }
+        }
+
+        /**
+         * Attempt to detect the text domain argument.
+         *
+         * @since 0.2.0
+         *
+         * @param string $content File content.
+         * @param int    $offset  Offset to start searching.
+         *
+         * @return string
+         */
+        protected function extract_text_domain( $content, $offset ) {
+                $slice = substr( $content, $offset );
+
+                if ( ! $slice ) {
+                        return '';
+                }
+
+                if ( ! preg_match( '/,\s*(?:array\s*\(|(?P<quote>[\'"]))(?P<domain>[a-zA-Z0-9_-]+)/', $slice, $matches ) ) {
+                        return '';
+                }
+
+                return isset( $matches['domain'] ) ? sanitize_key( $matches['domain'] ) : '';
+        }
+
+        /**
+         * Detect the line number of a match.
+         *
+         * @since 0.2.0
+         *
+         * @param string $content File content.
+         * @param int    $offset  Match offset.
+         *
+         * @return int
+         */
+        protected function detect_line_number( $content, $offset ) {
+                $before = substr( $content, 0, $offset );
+
+                if ( false === $before ) {
+                        return 0;
+                }
+
+                return substr_count( $before, "\n" ) + 1;
+        }
+
+        /**
+         * Turn an absolute path into a path relative to ABSPATH.
+         *
+         * @since 0.2.0
+         *
+         * @param string $path Absolute path.
+         *
+         * @return string
+         */
+        protected function make_relative_path( $path ) {
+                $path = wp_normalize_path( $path );
+                $root = wp_normalize_path( ABSPATH );
+
+                if ( strpos( $path, $root ) === 0 ) {
+                        return ltrim( substr( $path, strlen( $root ) ), '/' );
+                }
+
+                return $path;
+        }
+}

--- a/fp-multilanguage/includes/providers/class-provider-deepl.php
+++ b/fp-multilanguage/includes/providers/class-provider-deepl.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * DeepL translation provider.
+ *
+ * @package FP_Multilanguage
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+        exit;
+}
+
+require_once __DIR__ . '/interface-translator.php';
+
+/**
+ * Translate using DeepL API v2.
+ *
+ * @since 0.2.0
+ */
+class FPML_Provider_DeepL extends FPML_Base_Provider {
+        const API_BASE      = 'https://api.deepl.com/v2/translate';
+        const API_BASE_FREE = 'https://api-free.deepl.com/v2/translate';
+
+        /**
+         * {@inheritdoc}
+         */
+        public function get_slug() {
+                return 'deepl';
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function is_configured() {
+                return ! empty( $this->get_option( 'deepl_api_key' ) );
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function translate( $text, $source = 'it', $target = 'en', $domain = 'general' ) {
+                if ( '' === trim( (string) $text ) ) {
+                        return '';
+                }
+
+                if ( ! $this->is_configured() ) {
+                        return new WP_Error( 'fpml_deepl_missing_key', __( 'Configura una chiave API DeepL valida per procedere con la traduzione.', 'fp-multilanguage' ) );
+                }
+
+                $max_chars = (int) $this->get_option( 'max_chars', 4500 );
+                $chunks    = $this->chunk_text( $text, $max_chars );
+                $source    = strtoupper( $source );
+                $target    = strtoupper( $target );
+
+                $translated = '';
+
+                foreach ( $chunks as $chunk ) {
+                        $chunk_to_send = $this->apply_glossary_pre( $chunk, $source, $target, $domain );
+                        $result        = $this->request_translation( $chunk_to_send, $source, $target, $domain );
+
+                        if ( is_wp_error( $result ) ) {
+                                return $result;
+                        }
+
+                        $translated .= $this->apply_glossary_post( $result, $source, $target, $domain );
+                }
+
+                return $translated;
+        }
+
+        /**
+         * Perform DeepL request.
+         *
+         * @since 0.2.0
+         *
+         * @param string $text   Chunk text.
+         * @param string $source Source language.
+         * @param string $target Target language.
+         * @param string $domain Context domain.
+         *
+         * @return string|WP_Error
+         */
+        protected function request_translation( $text, $source, $target, $domain ) {
+                $endpoint = $this->get_option( 'deepl_use_free', false ) ? self::API_BASE_FREE : self::API_BASE;
+
+                $body = array(
+                        'text'                 => $text,
+                        'source_lang'          => strtoupper( $source ),
+                        'target_lang'          => ('EN' === strtoupper( $target ) ? 'EN-US' : strtoupper( $target )),
+                        'preserve_formatting'  => 1,
+                        'tag_handling'         => 'html',
+                        'outline_detection'    => 0,
+                        'formality'            => 'default',
+                        'split_sentences'      => 'nonewlines',
+                        'context'              => $domain,
+                );
+
+                $args = array(
+                        'headers' => array(
+                                'Authorization' => 'DeepL-Auth-Key ' . $this->get_option( 'deepl_api_key' ),
+                        ),
+                        'timeout' => 45,
+                        'body'    => $body,
+                );
+
+                $max_attempts = 3;
+
+                for ( $attempt = 1; $attempt <= $max_attempts; $attempt++ ) {
+                        $response = wp_remote_post( $endpoint, $args );
+
+                        if ( is_wp_error( $response ) ) {
+                                if ( $attempt === $max_attempts ) {
+                                        return new WP_Error( 'fpml_deepl_http_error', sprintf( __( 'Errore di connessione a DeepL: %s', 'fp-multilanguage' ), $response->get_error_message() ) );
+                                }
+
+                                $this->backoff( $attempt );
+                                continue;
+                        }
+
+                        $code = (int) wp_remote_retrieve_response_code( $response );
+                        if ( in_array( $code, array( 429, 500, 502, 503 ), true ) ) {
+                                if ( $attempt === $max_attempts ) {
+                                        return new WP_Error( 'fpml_deepl_rate_limit', __( 'DeepL ha restituito un errore di rate limit o temporaneo.', 'fp-multilanguage' ) );
+                                }
+
+                                $this->backoff( $attempt );
+                                continue;
+                        }
+
+                        if ( $code < 200 || $code >= 300 ) {
+                                $body_content = wp_remote_retrieve_body( $response );
+                                return new WP_Error( 'fpml_deepl_error', sprintf( __( 'Risposta non valida da DeepL (%1$d): %2$s', 'fp-multilanguage' ), $code, wp_kses_post( $body_content ) ) );
+                        }
+
+                        $data = json_decode( wp_remote_retrieve_body( $response ), true );
+                        if ( empty( $data['translations'][0]['text'] ) ) {
+                                return new WP_Error( 'fpml_deepl_empty', __( 'DeepL non ha restituito alcun contenuto traducibile.', 'fp-multilanguage' ) );
+                        }
+
+                        return (string) $data['translations'][0]['text'];
+                }
+
+                return new WP_Error( 'fpml_deepl_unexpected', __( 'Errore imprevisto durante la traduzione con DeepL.', 'fp-multilanguage' ) );
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        protected function get_rate_option_key() {
+                return 'rate_deepl';
+        }
+}

--- a/fp-multilanguage/includes/providers/class-provider-google.php
+++ b/fp-multilanguage/includes/providers/class-provider-google.php
@@ -1,0 +1,248 @@
+<?php
+/**
+ * Google Cloud Translation provider.
+ *
+ * @package FP_Multilanguage
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+        exit;
+}
+
+require_once __DIR__ . '/interface-translator.php';
+
+/**
+ * Translate using Google Cloud Translation API (v3 with v2 fallback).
+ *
+ * @since 0.2.0
+ */
+class FPML_Provider_Google extends FPML_Base_Provider {
+        const API_V3 = 'https://translation.googleapis.com/v3/projects/%s/locations/global:translateText';
+        const API_V2 = 'https://translation.googleapis.com/language/translate/v2';
+
+        /**
+         * {@inheritdoc}
+         */
+        public function get_slug() {
+                return 'google';
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function is_configured() {
+                return ! empty( $this->get_option( 'google_api_key' ) );
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function translate( $text, $source = 'it', $target = 'en', $domain = 'general' ) {
+                if ( '' === trim( (string) $text ) ) {
+                        return '';
+                }
+
+                if ( ! $this->is_configured() ) {
+                        return new WP_Error( 'fpml_google_missing_key', __( 'Configura un API key di Google Cloud Translation per procedere con la traduzione.', 'fp-multilanguage' ) );
+                }
+
+                $max_chars = (int) $this->get_option( 'max_chars', 4500 );
+                $chunks    = $this->chunk_text( $text, $max_chars );
+                $source    = strtolower( $source );
+                $target    = strtolower( $target );
+
+                $translated = '';
+
+                foreach ( $chunks as $chunk ) {
+                        $chunk_to_send = $this->apply_glossary_pre( $chunk, $source, $target, $domain );
+                        $result        = $this->request_translation( $chunk_to_send, $source, $target, $domain );
+
+                        if ( is_wp_error( $result ) ) {
+                                return $result;
+                        }
+
+                        $translated .= $this->apply_glossary_post( $result, $source, $target, $domain );
+                }
+
+                return $translated;
+        }
+
+        /**
+         * Perform Google Translation API request.
+         *
+         * @since 0.2.0
+         *
+         * @param string $text   Chunk text.
+         * @param string $source Source language.
+         * @param string $target Target language.
+         * @param string $domain Context domain.
+         *
+         * @return string|WP_Error
+         */
+        protected function request_translation( $text, $source, $target, $domain ) {
+                $api_key    = $this->get_option( 'google_api_key' );
+                $project_id = $this->get_option( 'google_project_id' );
+
+                $v3_response = null;
+                if ( ! empty( $project_id ) ) {
+                        $v3_response = $this->request_v3( $text, $source, $target, $domain, $project_id, $api_key );
+                        if ( is_string( $v3_response ) || is_wp_error( $v3_response ) ) {
+                                return $v3_response;
+                        }
+                        // On null fallback to v2.
+                }
+
+                return $this->request_v2( $text, $source, $target, $api_key );
+        }
+
+        /**
+         * Call Google Translation API v3.
+         *
+         * @since 0.2.0
+         *
+         * @param string $text       Chunk text.
+         * @param string $source     Source language.
+         * @param string $target     Target language.
+         * @param string $domain     Context domain.
+         * @param string $project_id Project identifier.
+         * @param string $api_key    API key.
+         *
+         * @return string|WP_Error|null Null when fallback is required.
+         */
+        protected function request_v3( $text, $source, $target, $domain, $project_id, $api_key ) {
+                $url  = sprintf( self::API_V3, rawurlencode( $project_id ) );
+                $url .= '?key=' . rawurlencode( $api_key );
+
+                $body = array(
+                        'contents'            => array( $text ),
+                        'sourceLanguageCode'  => $source,
+                        'targetLanguageCode'  => 'en' === $target ? 'en-US' : $target,
+                        'mimeType'            => 'text/html',
+                        'labels'              => array( 'fpml-domain' => sanitize_key( $domain ) ),
+                );
+
+                $args = array(
+                        'headers' => array(
+                                'Content-Type' => 'application/json',
+                        ),
+                        'timeout' => 45,
+                        'body'    => wp_json_encode( $body ),
+                );
+
+                $max_attempts = 3;
+
+                for ( $attempt = 1; $attempt <= $max_attempts; $attempt++ ) {
+                        $response = wp_remote_post( $url, $args );
+
+                        if ( is_wp_error( $response ) ) {
+                                if ( $attempt === $max_attempts ) {
+                                        return new WP_Error( 'fpml_google_http_error', sprintf( __( 'Errore di connessione a Google Translate: %s', 'fp-multilanguage' ), $response->get_error_message() ) );
+                                }
+
+                                $this->backoff( $attempt );
+                                continue;
+                        }
+
+                        $code = (int) wp_remote_retrieve_response_code( $response );
+                        if ( in_array( $code, array( 429, 500, 502, 503 ), true ) ) {
+                                if ( $attempt === $max_attempts ) {
+                                        return new WP_Error( 'fpml_google_rate_limit', __( 'Google Translate ha restituito un errore di rate limit o temporaneo.', 'fp-multilanguage' ) );
+                                }
+
+                                $this->backoff( $attempt );
+                                continue;
+                        }
+
+                        $body_content = wp_remote_retrieve_body( $response );
+
+                        if ( $code < 200 || $code >= 300 ) {
+                                // If v3 is not enabled fall back to v2.
+                                if ( in_array( $code, array( 400, 401, 403, 404 ), true ) ) {
+                                        return null;
+                                }
+
+                                return new WP_Error( 'fpml_google_error', sprintf( __( 'Risposta non valida da Google Translate v3 (%1$d): %2$s', 'fp-multilanguage' ), $code, wp_kses_post( $body_content ) ) );
+                        }
+
+                        $data = json_decode( $body_content, true );
+                        if ( empty( $data['translations'][0]['translatedText'] ) ) {
+                                return new WP_Error( 'fpml_google_empty', __( 'Google Translate v3 non ha restituito alcun contenuto traducibile.', 'fp-multilanguage' ) );
+                        }
+
+                        return (string) $data['translations'][0]['translatedText'];
+                }
+
+                return new WP_Error( 'fpml_google_unexpected', __( 'Errore imprevisto durante la traduzione con Google Translate v3.', 'fp-multilanguage' ) );
+        }
+
+        /**
+         * Call Google Translation API v2.
+         *
+         * @since 0.2.0
+         *
+         * @param string $text    Chunk text.
+         * @param string $source  Source language.
+         * @param string $target  Target language.
+         * @param string $api_key API key.
+         *
+         * @return string|WP_Error
+         */
+        protected function request_v2( $text, $source, $target, $api_key ) {
+                $args = array(
+                        'body'    => array(
+                                'q'      => $text,
+                                'source' => $source,
+                                'target' => 'en' === $target ? 'en' : $target,
+                                'format' => 'html',
+                                'key'    => $api_key,
+                        ),
+                        'timeout' => 45,
+                );
+
+                $max_attempts = 3;
+
+                for ( $attempt = 1; $attempt <= $max_attempts; $attempt++ ) {
+                        $response = wp_remote_post( self::API_V2, $args );
+
+                        if ( is_wp_error( $response ) ) {
+                                if ( $attempt === $max_attempts ) {
+                                        return new WP_Error( 'fpml_google_http_error', sprintf( __( 'Errore di connessione a Google Translate: %s', 'fp-multilanguage' ), $response->get_error_message() ) );
+                                }
+
+                                $this->backoff( $attempt );
+                                continue;
+                        }
+
+                        $code = (int) wp_remote_retrieve_response_code( $response );
+                        if ( in_array( $code, array( 429, 500, 502, 503 ), true ) ) {
+                                if ( $attempt === $max_attempts ) {
+                                        return new WP_Error( 'fpml_google_rate_limit', __( 'Google Translate ha restituito un errore di rate limit o temporaneo.', 'fp-multilanguage' ) );
+                                }
+
+                                $this->backoff( $attempt );
+                                continue;
+                        }
+
+                        $body_content = wp_remote_retrieve_body( $response );
+                        if ( $code < 200 || $code >= 300 ) {
+                                return new WP_Error( 'fpml_google_error', sprintf( __( 'Risposta non valida da Google Translate v2 (%1$d): %2$s', 'fp-multilanguage' ), $code, wp_kses_post( $body_content ) ) );
+                        }
+
+                        $data = json_decode( $body_content, true );
+                        if ( empty( $data['data']['translations'][0]['translatedText'] ) ) {
+                                return new WP_Error( 'fpml_google_empty', __( 'Google Translate v2 non ha restituito alcun contenuto traducibile.', 'fp-multilanguage' ) );
+                        }
+
+                        return (string) $data['data']['translations'][0]['translatedText'];
+                }
+
+                return new WP_Error( 'fpml_google_unexpected', __( 'Errore imprevisto durante la traduzione con Google Translate v2.', 'fp-multilanguage' ) );
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        protected function get_rate_option_key() {
+                return 'rate_google';
+        }
+}

--- a/fp-multilanguage/includes/providers/class-provider-libretranslate.php
+++ b/fp-multilanguage/includes/providers/class-provider-libretranslate.php
@@ -1,0 +1,158 @@
+<?php
+/**
+ * LibreTranslate provider.
+ *
+ * @package FP_Multilanguage
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+        exit;
+}
+
+require_once __DIR__ . '/interface-translator.php';
+
+/**
+ * Translate using LibreTranslate API.
+ *
+ * @since 0.2.0
+ */
+class FPML_Provider_LibreTranslate extends FPML_Base_Provider {
+        /**
+         * {@inheritdoc}
+         */
+        public function get_slug() {
+                return 'libretranslate';
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function is_configured() {
+                return ! empty( $this->get_option( 'libretranslate_api_url' ) );
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function translate( $text, $source = 'it', $target = 'en', $domain = 'general' ) {
+                if ( '' === trim( (string) $text ) ) {
+                        return '';
+                }
+
+                if ( ! $this->is_configured() ) {
+                        return new WP_Error( 'fpml_libretranslate_missing_url', __( 'Configura un endpoint LibreTranslate valido per procedere con la traduzione.', 'fp-multilanguage' ) );
+                }
+
+                $max_chars = (int) $this->get_option( 'max_chars', 4500 );
+                $chunks    = $this->chunk_text( $text, $max_chars );
+                $source    = strtolower( $source );
+                $target    = strtolower( $target );
+
+                $translated = '';
+
+                foreach ( $chunks as $chunk ) {
+                        $chunk_to_send = $this->apply_glossary_pre( $chunk, $source, $target, $domain );
+                        $result        = $this->request_translation( $chunk_to_send, $source, $target );
+
+                        if ( is_wp_error( $result ) ) {
+                                return $result;
+                        }
+
+                        $translated .= $this->apply_glossary_post( $result, $source, $target, $domain );
+                }
+
+                return $translated;
+        }
+
+        /**
+         * Perform LibreTranslate request.
+         *
+         * @since 0.2.0
+         *
+         * @param string $text   Chunk text.
+         * @param string $source Source language.
+         * @param string $target Target language.
+         *
+         * @return string|WP_Error
+         */
+        protected function request_translation( $text, $source, $target ) {
+                $base_url = rtrim( $this->get_option( 'libretranslate_api_url' ), '/' );
+
+                if ( empty( $base_url ) ) {
+                        return new WP_Error( 'fpml_libretranslate_missing_url', __( 'Specificare un endpoint LibreTranslate valido.', 'fp-multilanguage' ) );
+                }
+
+                $url = $base_url . '/translate';
+
+                $body = array(
+                        'q'      => $text,
+                        'source' => $source,
+                        'target' => 'en' === $target ? 'en' : $target,
+                        'format' => 'html',
+                );
+
+                $api_key = $this->get_option( 'libretranslate_api_key' );
+                if ( ! empty( $api_key ) ) {
+                        $body['api_key'] = $api_key;
+                }
+
+                $args = array(
+                        'timeout' => 45,
+                        'headers' => array(
+                                'Accept'       => 'application/json',
+                                'Content-Type' => 'application/json',
+                        ),
+                        'body'    => wp_json_encode( $body ),
+                );
+
+                $max_attempts = 3;
+
+                for ( $attempt = 1; $attempt <= $max_attempts; $attempt++ ) {
+                        $response = wp_remote_post( $url, $args );
+
+                        if ( is_wp_error( $response ) ) {
+                                if ( $attempt === $max_attempts ) {
+                                        return new WP_Error( 'fpml_libretranslate_http_error', sprintf( __( 'Errore di connessione a LibreTranslate: %s', 'fp-multilanguage' ), $response->get_error_message() ) );
+                                }
+
+                                $this->backoff( $attempt );
+                                continue;
+                        }
+
+                        $code = (int) wp_remote_retrieve_response_code( $response );
+                        if ( in_array( $code, array( 429, 500, 502, 503 ), true ) ) {
+                                if ( $attempt === $max_attempts ) {
+                                        return new WP_Error( 'fpml_libretranslate_rate_limit', __( 'LibreTranslate ha restituito un errore di rate limit o temporaneo.', 'fp-multilanguage' ) );
+                                }
+
+                                $this->backoff( $attempt );
+                                continue;
+                        }
+
+                        $body_content = wp_remote_retrieve_body( $response );
+                        if ( $code < 200 || $code >= 300 ) {
+                                return new WP_Error( 'fpml_libretranslate_error', sprintf( __( 'Risposta non valida da LibreTranslate (%1$d): %2$s', 'fp-multilanguage' ), $code, wp_kses_post( $body_content ) ) );
+                        }
+
+                        $data = json_decode( $body_content, true );
+                        if ( isset( $data['translatedText'] ) ) {
+                                return (string) $data['translatedText'];
+                        }
+
+                        if ( isset( $data['error'] ) ) {
+                                return new WP_Error( 'fpml_libretranslate_error', sprintf( __( 'LibreTranslate ha restituito un errore: %s', 'fp-multilanguage' ), wp_kses_post( $data['error'] ) ) );
+                        }
+
+                        return new WP_Error( 'fpml_libretranslate_empty', __( 'LibreTranslate non ha restituito alcun contenuto traducibile.', 'fp-multilanguage' ) );
+                }
+
+                return new WP_Error( 'fpml_libretranslate_unexpected', __( 'Errore imprevisto durante la traduzione con LibreTranslate.', 'fp-multilanguage' ) );
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        protected function get_rate_option_key() {
+                return 'rate_libretranslate';
+        }
+}

--- a/fp-multilanguage/includes/providers/class-provider-openai.php
+++ b/fp-multilanguage/includes/providers/class-provider-openai.php
@@ -1,0 +1,197 @@
+<?php
+/**
+ * OpenAI translation provider.
+ *
+ * @package FP_Multilanguage
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+        exit;
+}
+
+require_once __DIR__ . '/interface-translator.php';
+
+/**
+ * Translate content using OpenAI Chat Completions.
+ *
+ * @since 0.2.0
+ */
+class FPML_Provider_OpenAI extends FPML_Base_Provider {
+        const API_ENDPOINT = 'https://api.openai.com/v1/chat/completions';
+
+        /**
+         * {@inheritdoc}
+         */
+        public function get_slug() {
+                return 'openai';
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function is_configured() {
+                $key   = $this->get_option( 'openai_api_key' );
+                $model = $this->get_option( 'openai_model', 'gpt-4o-mini' );
+
+                return ! empty( $key ) && ! empty( $model );
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function translate( $text, $source = 'it', $target = 'en', $domain = 'general' ) {
+                if ( '' === trim( (string) $text ) ) {
+                        return '';
+                }
+
+                if ( ! $this->is_configured() ) {
+                        return new WP_Error( 'fpml_openai_missing_key', __( 'Configura una chiave API OpenAI valida per procedere con la traduzione.', 'fp-multilanguage' ) );
+                }
+
+                $max_chars = (int) $this->get_option( 'max_chars', 4500 );
+                $chunks    = $this->chunk_text( $text, $max_chars );
+                $source    = strtolower( $source );
+                $target    = strtolower( $target );
+
+                $translated = '';
+                $marketing  = (bool) $this->get_option( 'marketing_tone', false );
+
+                foreach ( $chunks as $chunk ) {
+                        $chunk_to_send = $this->apply_glossary_pre( $chunk, $source, $target, $domain );
+                        $result        = $this->request_translation( $chunk_to_send, $source, $target, $domain, $marketing );
+
+                        if ( is_wp_error( $result ) ) {
+                                return $result;
+                        }
+
+                        $translated .= $this->apply_glossary_post( $result, $source, $target, $domain );
+                }
+
+                return $translated;
+        }
+
+        /**
+         * Perform request to OpenAI API.
+         *
+         * @since 0.2.0
+         *
+         * @param string $text      Chunk text.
+         * @param string $source    Source language.
+         * @param string $target    Target language.
+         * @param string $domain    Context domain.
+         * @param bool   $marketing Whether to apply a marketing tone.
+         *
+         * @return string|WP_Error
+         */
+        protected function request_translation( $text, $source, $target, $domain, $marketing ) {
+                $payload = array(
+                        'model'       => $this->get_option( 'openai_model', 'gpt-4o-mini' ),
+                        'temperature' => 0.2,
+                        'messages'    => array(
+                                array(
+                                        'role'    => 'system',
+                                        'content' => $this->get_system_prompt( $marketing ),
+                                ),
+                                array(
+                                        'role'    => 'user',
+                                        'content' => $this->build_user_prompt( $text, $source, $target, $domain ),
+                                ),
+                        ),
+                );
+
+                $args = array(
+                        'headers' => array(
+                                'Authorization' => 'Bearer ' . $this->get_option( 'openai_api_key' ),
+                                'Content-Type'  => 'application/json',
+                        ),
+                        'body'    => wp_json_encode( $payload ),
+                        'timeout' => 45,
+                );
+
+                $max_attempts = 3;
+
+                for ( $attempt = 1; $attempt <= $max_attempts; $attempt++ ) {
+                        $response = wp_remote_post( self::API_ENDPOINT, $args );
+
+                        if ( is_wp_error( $response ) ) {
+                                if ( $attempt === $max_attempts ) {
+                                        return new WP_Error( 'fpml_openai_http_error', sprintf( __( 'Errore di connessione a OpenAI: %s', 'fp-multilanguage' ), $response->get_error_message() ) );
+                                }
+
+                                $this->backoff( $attempt );
+                                continue;
+                        }
+
+                        $code = (int) wp_remote_retrieve_response_code( $response );
+                        if ( in_array( $code, array( 429, 500, 502, 503 ), true ) ) {
+                                if ( $attempt === $max_attempts ) {
+                                        return new WP_Error( 'fpml_openai_rate_limit', __( 'OpenAI ha restituito un errore di rate limit o temporaneo.', 'fp-multilanguage' ) );
+                                }
+
+                                $this->backoff( $attempt );
+                                continue;
+                        }
+
+                        if ( $code < 200 || $code >= 300 ) {
+                                $body = wp_remote_retrieve_body( $response );
+                                return new WP_Error( 'fpml_openai_error', sprintf( __( 'Risposta non valida da OpenAI (%1$d): %2$s', 'fp-multilanguage' ), $code, wp_kses_post( $body ) ) );
+                        }
+
+                        $data = json_decode( wp_remote_retrieve_body( $response ), true );
+
+                        if ( empty( $data['choices'][0]['message']['content'] ) ) {
+                                return new WP_Error( 'fpml_openai_empty', __( 'OpenAI non ha restituito alcun contenuto traducibile.', 'fp-multilanguage' ) );
+                        }
+
+                        return (string) $data['choices'][0]['message']['content'];
+                }
+
+                return new WP_Error( 'fpml_openai_unexpected', __( 'Errore imprevisto durante la traduzione con OpenAI.', 'fp-multilanguage' ) );
+        }
+
+        /**
+         * Build system prompt.
+         *
+         * @since 0.2.0
+         *
+         * @param bool $marketing Whether marketing tone is enabled.
+         *
+         * @return string
+         */
+        protected function get_system_prompt( $marketing ) {
+                $prompt  = 'You are a professional Italian to English (United States) translator. Preserve HTML tags, attributes, shortcodes, and URLs. Never translate shortcode names, attribute values, or code samples. Respond with English content only.';
+                $prompt .= ' Maintain neutral, clear language suitable for a broad audience.';
+
+                if ( $marketing ) {
+                        $prompt .= ' When possible, adopt a slightly promotional tone while remaining natural and trustworthy.';
+                }
+
+                return $prompt;
+        }
+
+        /**
+         * Build user prompt.
+         *
+         * @since 0.2.0
+         *
+         * @param string $text   Input chunk.
+         * @param string $source Source language.
+         * @param string $target Target language.
+         * @param string $domain Context domain.
+         *
+         * @return string
+         */
+        protected function build_user_prompt( $text, $source, $target, $domain ) {
+                $instructions  = sprintf( 'Translate the following %1$s content from %2$s to %3$s. Preserve formatting, HTML structure, and shortcodes exactly.', $domain, $source, $target );
+                $instructions .= ' Do not translate URLs, HTML attributes, CSS classes, IDs, or shortcode parameters. Return only the translated content without additional commentary.';
+
+                return $instructions . "\n\n" . $text;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        protected function get_rate_option_key() {
+                return 'rate_openai';
+        }
+}

--- a/fp-multilanguage/includes/providers/interface-translator.php
+++ b/fp-multilanguage/includes/providers/interface-translator.php
@@ -1,0 +1,327 @@
+<?php
+/**
+ * Translator interface and shared helpers.
+ *
+ * @package FP_Multilanguage
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+        exit;
+}
+
+/**
+ * Translator interface.
+ *
+ * @since 0.2.0
+ */
+interface FPML_TranslatorInterface {
+        /**
+         * Unique provider slug.
+         *
+         * @since 0.2.0
+         *
+         * @return string
+         */
+        public function get_slug();
+
+        /**
+         * Translate text from source to target language.
+         *
+         * @since 0.2.0
+         *
+         * @param string $text   Text to translate.
+         * @param string $source Source language code.
+         * @param string $target Target language code.
+         * @param string $domain Context domain (marketing, general, seo...).
+         *
+         * @return string|WP_Error
+         */
+        public function translate( $text, $source = 'it', $target = 'en', $domain = 'general' );
+
+        /**
+         * Determine if the provider is ready to be used.
+         *
+         * @since 0.2.0
+         *
+         * @return bool
+         */
+        public function is_configured();
+
+        /**
+         * Estimate translation cost for a given text.
+         *
+         * @since 0.2.0
+         *
+         * @param string $text Text to evaluate.
+         *
+         * @return float
+         */
+        public function estimate_cost( $text );
+}
+
+/**
+ * Base provider helper.
+ *
+ * @since 0.2.0
+ */
+abstract class FPML_Base_Provider implements FPML_TranslatorInterface {
+        /**
+         * Cached settings instance.
+         *
+         * @var FPML_Settings
+         */
+        protected $settings;
+
+        /**
+         * Constructor.
+         */
+        public function __construct() {
+                $this->settings = FPML_Settings::instance();
+        }
+
+        /**
+         * Retrieve an option from settings.
+         *
+         * @since 0.2.0
+         *
+         * @param string $key     Option key.
+         * @param mixed  $default Default value.
+         *
+         * @return mixed
+         */
+        protected function get_option( $key, $default = '' ) {
+                return $this->settings ? $this->settings->get( $key, $default ) : $default;
+        }
+
+        /**
+         * Apply glossary replacements before translation.
+         *
+         * @since 0.2.0
+         *
+         * @param string $text   Text to process.
+         * @param string $source Source language code.
+         * @param string $target Target language code.
+         * @param string $domain Context domain.
+         *
+         * @return string
+         */
+        protected function apply_glossary_pre( $text, $source, $target, $domain ) {
+                /**
+                 * Filter glossary substitutions before translation.
+                 *
+                 * @since 0.2.0
+                 *
+                 * @param string              $text   Text to process.
+                 * @param string              $source Source language.
+                 * @param string              $target Target language.
+                 * @param string              $domain Context domain.
+                 * @param FPML_Base_Provider $provider Provider instance.
+                 */
+                return apply_filters( 'fpml_glossary_pre_translate', $text, $source, $target, $domain, $this );
+        }
+
+        /**
+         * Apply glossary replacements after translation.
+         *
+         * @since 0.2.0
+         *
+         * @param string $text   Text to process.
+         * @param string $source Source language code.
+         * @param string $target Target language code.
+         * @param string $domain Context domain.
+         *
+         * @return string
+         */
+        protected function apply_glossary_post( $text, $source, $target, $domain ) {
+                /**
+                 * Filter glossary substitutions after translation.
+                 *
+                 * @since 0.2.0
+                 *
+                 * @param string              $text   Text to process.
+                 * @param string              $source Source language.
+                 * @param string              $target Target language.
+                 * @param string              $domain Context domain.
+                 * @param FPML_Base_Provider $provider Provider instance.
+                 */
+                return apply_filters( 'fpml_glossary_post_translate', $text, $source, $target, $domain, $this );
+        }
+
+        /**
+         * Chunk large texts while preserving HTML structure.
+         *
+         * @since 0.2.0
+         *
+         * @param string $text  Text to split.
+         * @param int    $limit Character limit per chunk.
+         *
+         * @return array
+         */
+        protected function chunk_text( $text, $limit ) {
+                $limit = max( 500, absint( $limit ) );
+
+                if ( mb_strlen( $text, 'UTF-8' ) <= $limit ) {
+                        return array( $text );
+                }
+
+                $parts  = function_exists( 'wp_html_split' ) ? wp_html_split( $text ) : array( $text );
+                $chunks = array();
+                $buffer = '';
+
+                foreach ( $parts as $part ) {
+                        $part_length = mb_strlen( $part, 'UTF-8' );
+
+                        if ( $part_length > $limit ) {
+                                $subparts = $this->split_long_text( $part, $limit );
+                                foreach ( $subparts as $subpart ) {
+                                        $chunks[] = $subpart;
+                                }
+                                $buffer = '';
+                                continue;
+                        }
+
+                        $buffer_length = mb_strlen( $buffer, 'UTF-8' );
+                        if ( $buffer_length + $part_length > $limit && '' !== $buffer ) {
+                                $chunks[] = $buffer;
+                                $buffer   = '';
+                        }
+
+                        $buffer .= $part;
+                }
+
+                if ( '' !== $buffer ) {
+                        $chunks[] = $buffer;
+                }
+
+                if ( empty( $chunks ) ) {
+                        $chunks = array( $text );
+                }
+
+                return $chunks;
+        }
+
+        /**
+         * Split an oversized text chunk by whitespace to respect limits.
+         *
+         * @since 0.2.0
+         *
+         * @param string $text  Text to split.
+         * @param int    $limit Character limit per chunk.
+         *
+         * @return array
+         */
+        protected function split_long_text( $text, $limit ) {
+                $segments = array();
+                $length   = mb_strlen( $text, 'UTF-8' );
+                $offset   = 0;
+
+                while ( $offset < $length ) {
+                        $remaining = $length - $offset;
+                        $take      = min( $limit, $remaining );
+                        $slice     = mb_substr( $text, $offset, $take, 'UTF-8' );
+
+                        if ( $take === $remaining ) {
+                                $segments[] = $slice;
+                                break;
+                        }
+
+                        $breakpoint = $this->find_breakpoint( $slice );
+                        $segments[] = mb_substr( $slice, 0, $breakpoint, 'UTF-8' );
+                        $offset    += $breakpoint;
+                }
+
+                return $segments;
+        }
+
+        /**
+         * Find a safe breakpoint for a slice.
+         *
+         * @since 0.2.0
+         *
+         * @param string $slice Slice to inspect.
+         *
+         * @return int
+         */
+        protected function find_breakpoint( $slice ) {
+                $length = mb_strlen( $slice, 'UTF-8' );
+
+                $candidates = array( '\n\n', '\n', '. ', ' ', '\t' );
+                foreach ( $candidates as $candidate ) {
+                        $pos = mb_strrpos( $slice, $candidate, 0, 'UTF-8' );
+                        if ( false !== $pos && $pos > 0 ) {
+                                return $pos + mb_strlen( $candidate, 'UTF-8' );
+                        }
+                }
+
+                return $length;
+        }
+
+        /**
+         * Backoff helper with jitter.
+         *
+         * @since 0.2.0
+         *
+         * @param int $attempt Attempt number starting from 1.
+         *
+         * @return void
+         */
+        protected function backoff( $attempt ) {
+                $attempt = max( 1, absint( $attempt ) );
+                $delay   = min( pow( 2, $attempt - 1 ), 30 );
+                $jitter  = function_exists( 'wp_rand' ) ? wp_rand( 0, 1000 ) / 1000 : mt_rand( 0, 1000 ) / 1000;
+                $delay  += $jitter;
+
+                if ( function_exists( 'wp_sleep' ) ) {
+                        wp_sleep( $delay );
+                } else {
+                        usleep( (int) ( $delay * 1000000 ) );
+                }
+        }
+
+        /**
+         * Retrieve rate option key.
+         *
+         * @since 0.2.0
+         *
+         * @return string
+         */
+        abstract protected function get_rate_option_key();
+
+        /**
+         * Estimate cost based on configured rate per 1000 characters.
+         *
+         * @since 0.2.0
+         *
+         * @param string $text Text to evaluate.
+         *
+         * @return float
+         */
+        public function estimate_cost( $text ) {
+                $rate_option = $this->get_option( $this->get_rate_option_key(), '' );
+                if ( '' === $rate_option ) {
+                        return 0.0;
+                }
+
+                $rate_option = str_replace( ',', '.', $rate_option );
+                $rate        = (float) $rate_option;
+
+                if ( $rate <= 0 ) {
+                        return 0.0;
+                }
+
+                $characters = mb_strlen( $text, 'UTF-8' );
+                $cost       = ( $characters / 1000 ) * $rate;
+
+                /**
+                 * Filter the estimated cost before returning.
+                 *
+                 * @since 0.2.0
+                 *
+                 * @param float               $cost       Estimated cost.
+                 * @param int                 $characters Character count.
+                 * @param float               $rate       Rate per 1000 characters.
+                 * @param FPML_Base_Provider $provider   Provider instance.
+                 */
+                return (float) apply_filters( 'fpml_translate_estimated_cost', $cost, $characters, $rate, $this );
+        }
+}

--- a/fp-multilanguage/languages/fp-multilanguage-en_US.po
+++ b/fp-multilanguage/languages/fp-multilanguage-en_US.po
@@ -1,0 +1,11 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: FP Multilanguage 0.2.0\\n"
+"POT-Creation-Date: 2024-07-09 00:00+0000\\n"
+"PO-Revision-Date: 2024-07-09 00:00+0000\\n"
+"Language: en_US\\n"
+"MIME-Version: 1.0\\n"
+"Content-Type: text/plain; charset=UTF-8\\n"
+"Content-Transfer-Encoding: 8bit\\n"
+"X-Generator: FPML-Generator\\n"
+

--- a/fp-multilanguage/languages/fp-multilanguage-it_IT.po
+++ b/fp-multilanguage/languages/fp-multilanguage-it_IT.po
@@ -1,0 +1,11 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: FP Multilanguage 0.2.0\\n"
+"POT-Creation-Date: 2024-07-09 00:00+0000\\n"
+"PO-Revision-Date: 2024-07-09 00:00+0000\\n"
+"Language: it_IT\\n"
+"MIME-Version: 1.0\\n"
+"Content-Type: text/plain; charset=UTF-8\\n"
+"Content-Transfer-Encoding: 8bit\\n"
+"X-Generator: FPML-Generator\\n"
+

--- a/fp-multilanguage/readme.txt
+++ b/fp-multilanguage/readme.txt
@@ -1,0 +1,58 @@
+=== FP Multilanguage ===
+Contributors: francescopasseri
+Tags: translation, multilanguage, openai, deepl, google translate, seo
+Requires at least: 5.8
+Tested up to: 6.5
+Requires PHP: 7.4
+Stable tag: 0.2.1
+License: GPLv2 or later
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
+
+Plugin WordPress per tradurre automaticamente contenuti e SEO dall'italiano all'inglese con provider reali (OpenAI, DeepL, Google, LibreTranslate), gestione coda e routing /en/.
+
+== Descrizione ==
+FP Multilanguage duplica contenuti inglesi sincronizzati con l'originale italiano, include routing dedicato /en/ o query string, sitemap EN, gestione slug, hreflang/canonical e supporto per Gutenberg, ACF e campi personalizzati.
+
+== Installazione ==
+1. Carica la cartella `fp-multilanguage` in `/wp-content/plugins/`.
+2. Attiva il plugin tramite il menu "Plugin" in WordPress.
+3. Configura i provider e le opzioni in **Impostazioni → FP Multilanguage**.
+
+== Test rapidi ==
+* Creare Pagina IT → verifica duplicato EN su /en/... con hreflang/canonical.
+* Modificare titolo IT → EN marcata outdated → ritradotta solo parte modificata.
+* Creare Categoria + assegnazione post → EN crea termine e associazione.
+* Attivare provider con chiave → Test provider OK in Diagnostics.
+* Verificare sitemap EN e meta OG/Twitter.
+* Verificare redirect browser language e switcher.
+* WP-CLI: `wp fpml queue run` processa N elementi (batch size).
+
+
+== Cron & Diagnostics ==
+La scheda *Diagnostics* mette in evidenza KPI della coda (job in pending, completati, errori), stima parole/costi basata sulle tariffe configurate e riporta gli ultimi log e gli errori recenti. Dai pulsanti puoi lanciare un batch immediato, avviare un reindex completo o testare il provider direttamente via REST protetto.
+
+Se `DISABLE_WP_CRON` è impostato a `true`, configura un cron di sistema per mantenere attiva la pipeline. Esempio ogni 5 minuti con WP-CLI (sostituisci il percorso alla root WordPress):
+
+```
+*/5 * * * * cd /percorso/sito && wp cron event run --due-now >/dev/null 2>&1
+```
+
+In alternativa, puoi eseguire direttamente `wp-cron.php`:
+
+```
+*/5 * * * * php /percorso/sito/wp-cron.php >/dev/null 2>&1
+```
+
+== Compatibilità ==
+* Se WPML o Polylang sono attivi, FP Multilanguage entra in modalità *assistita*: lascia disponibili provider, glossario, override stringhe ed export/import ma disattiva duplicazione automatica, routing /en/, sitemap EN e coda interna. La UI mostra un avviso e blocca comandi REST/WP-CLI sulla coda per evitare conflitti.
+
+== Changelog ==
+= 0.2.1 =
+- Fix: preservazione strutture ACF/repeater con traduzione ricorsiva delle sole stringhe.
+- Fix: rispetto effettivo di “Shortcode esclusi” con masking/restore sicuro in diff e processor.
+- Docs: BUILD-STATE aggiornato alla Fase 14.
+
+= 0.2.0 =
+* Versione iniziale in sviluppo.
+* Dashboard diagnostica con KPI, test provider e stima costi dalla scheda Diagnostics.
+* Notice WP-Cron con esempi di crontab quando DISABLE_WP_CRON è attivo.

--- a/fp-multilanguage/rest/class-rest-admin.php
+++ b/fp-multilanguage/rest/class-rest-admin.php
@@ -1,0 +1,238 @@
+<?php
+/**
+ * Internal REST API for admin actions.
+ *
+ * @package FP_Multilanguage
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+        exit;
+}
+
+/**
+ * Register REST endpoints used by the admin UI.
+ *
+ * @since 0.2.0
+ */
+class FPML_REST_Admin {
+        /**
+         * Singleton instance.
+         *
+         * @var FPML_REST_Admin|null
+         */
+        protected static $instance = null;
+
+        /**
+         * Retrieve singleton instance.
+         *
+         * @since 0.2.0
+         *
+         * @return FPML_REST_Admin
+         */
+        public static function instance() {
+                if ( null === self::$instance ) {
+                        self::$instance = new self();
+                }
+
+                return self::$instance;
+        }
+
+        /**
+         * Constructor.
+         */
+        protected function __construct() {
+                add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+        }
+
+        /**
+         * Register REST routes.
+         *
+         * @since 0.2.0
+         *
+         * @return void
+         */
+        public function register_routes() {
+                register_rest_route(
+                        'fpml/v1',
+                        '/queue/run',
+                        array(
+                                'methods'             => \WP_REST_Server::CREATABLE,
+                                'callback'            => array( $this, 'handle_run_queue' ),
+                                'permission_callback' => array( $this, 'check_permissions' ),
+                        )
+                );
+
+                register_rest_route(
+                        'fpml/v1',
+                        '/test-provider',
+                        array(
+                                'methods'             => \WP_REST_Server::CREATABLE,
+                                'callback'            => array( $this, 'handle_test_provider' ),
+                                'permission_callback' => array( $this, 'check_permissions' ),
+                        )
+                );
+
+                register_rest_route(
+                        'fpml/v1',
+                        '/reindex',
+                        array(
+                                'methods'             => \WP_REST_Server::CREATABLE,
+                                'callback'            => array( $this, 'handle_reindex' ),
+                                'permission_callback' => array( $this, 'check_permissions' ),
+                        )
+                );
+        }
+
+        /**
+         * Ensure the current request is authorized.
+         *
+         * @since 0.2.0
+         *
+         * @param WP_REST_Request $request Request instance.
+         *
+         * @return bool|WP_Error
+         */
+        public function check_permissions( $request ) {
+                if ( ! current_user_can( 'manage_options' ) ) {
+                        return new WP_Error(
+                                'fpml_rest_forbidden',
+                                __( 'Permessi insufficienti.', 'fp-multilanguage' ),
+                                array( 'status' => rest_authorization_required_code() )
+                        );
+                }
+
+                $nonce = $request->get_header( 'X-WP-Nonce' );
+
+                if ( empty( $nonce ) ) {
+                        $nonce = $request->get_param( '_wpnonce' );
+                }
+
+                if ( ! $nonce || ! wp_verify_nonce( $nonce, 'wp_rest' ) ) {
+                        return new WP_Error(
+                                'fpml_rest_nonce_invalid',
+                                __( 'Nonce non valido.', 'fp-multilanguage' ),
+                                array( 'status' => rest_authorization_required_code() )
+                        );
+                }
+
+                return true;
+        }
+
+        /**
+         * Process a queue batch via REST.
+         *
+         * @since 0.2.0
+         *
+         * @param WP_REST_Request $request Request instance.
+         *
+         * @return WP_REST_Response|WP_Error
+         */
+        public function handle_run_queue( $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+                $plugin = FPML_Plugin::instance();
+
+                if ( $plugin->is_assisted_mode() ) {
+                        return new WP_Error(
+                                'fpml_assisted_mode',
+                                __( 'Modalità assistita attiva: la coda interna è disabilitata.', 'fp-multilanguage' ),
+                                array( 'status' => 409 )
+                        );
+                }
+
+                $processor = FPML_Processor::instance();
+                $result    = $processor->run_queue();
+
+                if ( is_wp_error( $result ) ) {
+                        $result->add_data( array( 'status' => 409 ), $result->get_error_code() );
+
+                        return $result;
+                }
+
+                return rest_ensure_response(
+                        array(
+                                'success' => true,
+                                'summary' => $result,
+                        )
+                );
+        }
+
+        /**
+         * Execute a provider test translation.
+         *
+         * @since 0.2.0
+         *
+         * @param WP_REST_Request $request Request instance.
+         *
+         * @return WP_REST_Response|WP_Error
+         */
+        public function handle_test_provider( $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+                $processor  = FPML_Processor::instance();
+                $translator = $processor->get_translator_instance();
+
+                if ( is_wp_error( $translator ) ) {
+                        $translator->add_data( array( 'status' => 400 ), $translator->get_error_code() );
+
+                        return $translator;
+                }
+
+                $sample  = __( 'Questa è una frase di prova per FP Multilanguage.', 'fp-multilanguage' );
+                $start   = microtime( true );
+                $output  = $translator->translate( $sample, 'it', 'en', 'general' );
+                $elapsed = microtime( true ) - $start;
+
+                if ( is_wp_error( $output ) ) {
+                        $output->add_data( array( 'status' => 400 ), $output->get_error_code() );
+
+                        return $output;
+                }
+
+                $cost = $translator->estimate_cost( $sample );
+
+                return rest_ensure_response(
+                        array(
+                                'success'         => true,
+                                'provider'        => FPML_Settings::instance()->get( 'provider', '' ),
+                                'elapsed'         => round( $elapsed, 4 ),
+                                'characters'      => mb_strlen( $sample, 'UTF-8' ),
+                                'estimated_cost'  => $cost,
+                                'sample'          => $sample,
+                                'translation'     => wp_kses_post( $output ),
+                        )
+                );
+        }
+
+        /**
+         * Trigger a full reindex via REST.
+         *
+         * @since 0.2.0
+         *
+         * @param WP_REST_Request $request Request instance.
+         *
+         * @return WP_REST_Response
+         */
+        public function handle_reindex( $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+                $plugin = FPML_Plugin::instance();
+
+                if ( $plugin->is_assisted_mode() ) {
+                        return new WP_Error(
+                                'fpml_assisted_mode',
+                                __( 'Modalità assistita attiva: il reindex automatico è disabilitato.', 'fp-multilanguage' ),
+                                array( 'status' => 409 )
+                        );
+                }
+
+                $summary = $plugin->reindex_content();
+
+                if ( is_wp_error( $summary ) ) {
+                        $summary->add_data( array( 'status' => 409 ), $summary->get_error_code() );
+
+                        return $summary;
+                }
+
+                return rest_ensure_response(
+                        array(
+                                'success' => true,
+                                'summary' => $summary,
+                        )
+                );
+        }
+}

--- a/fp-multilanguage/uninstall.php
+++ b/fp-multilanguage/uninstall.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Uninstall handler.
+ *
+ * @package FP_Multilanguage
+ */
+
+if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
+exit;
+}
+
+$remove_data = get_option( 'fpml_remove_data', false );
+
+if ( ! $remove_data ) {
+return;
+}
+
+$option_keys = array(
+'fpml_settings',
+'fpml_logs',
+'fpml_queue_lock',
+'fpml_slug_redirects',
+'fpml_glossary',
+);
+
+foreach ( $option_keys as $key ) {
+delete_option( $key );
+delete_site_option( $key );
+}
+
+global $wpdb;
+$table_name = $wpdb->prefix . 'fpml_queue';
+$wpdb->query( "DROP TABLE IF EXISTS {$table_name}" );


### PR DESCRIPTION
## Summary
- bump the plugin header and version constant to 0.2.1
- update the readme stable tag and add the 0.2.1 changelog entry
- append the 0.2.1 patch release note to the build-state log

## Testing
- php -l fp-multilanguage/fp-multilanguage.php

------
https://chatgpt.com/codex/tasks/task_e_68d9b0f0337c832fb372dcffcf4c5c29