### PR TITLE
Add GitHub Actions workflow for packaging FP Multilanguage

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+/.github export-ignore
+/build export-ignore
+/dist export-ignore
+/tests export-ignore
+/test export-ignore
+/.vscode export-ignore
+/.idea export-ignore
+/.gitignore export-ignore
+/.gitattributes export-ignore
+/node_modules export-ignore
+/vendor export-ignore
+/docs export-ignore

--- a/.github/workflows/build-zip.yml
+++ b/.github/workflows/build-zip.yml
@@ -1,0 +1,94 @@
+name: Build Plugin ZIP
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+      - 'V*'
+      - '[0-9]*'
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  lint:
+    name: PHP Lint
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+      - name: PHP Syntax Check
+        run: |
+          find . -type f -name "*.php" -print0 | xargs -0 -n1 -P4 php -l
+
+  build:
+    name: Build ZIP
+    runs-on: ubuntu-latest
+    needs: lint
+    strategy:
+      fail-fast: false
+    outputs:
+      ARTIFACT: ${{ steps.build_zip.outputs.ARTIFACT }}
+      ARTIFACT_NAME: ${{ steps.build_zip.outputs.ARTIFACT_NAME }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+      - name: Build plugin archive
+        id: build_zip
+        run: |
+          ./scripts/build-zip.sh
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.build_zip.outputs.ARTIFACT_NAME }}
+          path: ${{ steps.build_zip.outputs.ARTIFACT }}
+          if-no-files-found: error
+
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    strategy:
+      fail-fast: false
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.build.outputs.ARTIFACT_NAME }}
+          path: dist
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref_name }}
+          release_name: ${{ github.ref_name }}
+          draft: false
+          prerelease: ${{ contains(github.ref_name, '-rc') || contains(github.ref_name, '-beta') }}
+      - name: Upload Release Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: dist/${{ needs.build.outputs.ARTIFACT_NAME }}
+          asset_name: ${{ needs.build.outputs.ARTIFACT_NAME }}
+          asset_content_type: application/zip

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/build/
+/dist/
+*.zip

--- a/scripts/build-zip.sh
+++ b/scripts/build-zip.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SLUG="fp-multilanguage"
+PLUGIN_DIR="${SLUG}"
+MAIN_FILE="${PLUGIN_DIR}/${SLUG}.php"
+STAGE="build/${SLUG}"
+DIST_DIR="dist"
+
+if [[ ! -f "${MAIN_FILE}" ]]; then
+  echo "Errore: file principale del plugin non trovato: ${MAIN_FILE}" >&2
+  exit 1
+fi
+
+VERSION=$(grep -Ei '^\s*\*\s*Version:\s*' "${MAIN_FILE}" | sed -E 's/.*Version:\s*([0-9A-Za-z\.-]+).*/\1/' || true)
+if [[ -z "${VERSION}" ]]; then
+  echo "Errore: impossibile determinare la versione dal file ${MAIN_FILE}" >&2
+  exit 1
+fi
+
+OUTPUT="${DIST_DIR}/${SLUG}-${VERSION}.zip"
+ARTIFACT_NAME="$(basename "${OUTPUT}")"
+
+EXCLUDES=(
+  ".git"
+  ".github"
+  ".gitignore"
+  ".gitattributes"
+  "build"
+  "dist"
+  "node_modules"
+  "vendor"
+  "tests"
+  "test"
+  ".vscode"
+  ".idea"
+  "docs"
+  "*~"
+  "*.bak"
+  "*.tmp"
+)
+
+printf 'Versione rilevata: %s\n' "${VERSION}"
+printf 'Esclusioni principali:\n'
+for pattern in "${EXCLUDES[@]}"; do
+  printf '  - %s\n' "$pattern"
+done
+
+rm -rf "${DIST_DIR}" "build"
+mkdir -p "${DIST_DIR}" "${STAGE}"
+
+RSYNC_EXCLUDES=()
+for pattern in "${EXCLUDES[@]}"; do
+  RSYNC_EXCLUDES+=("--exclude=${pattern}")
+done
+
+rsync -a "${RSYNC_EXCLUDES[@]}" "${PLUGIN_DIR}/" "${STAGE}/"
+
+if find "${STAGE}" -type f -name '*.php' -print -quit | grep -q '.'; then
+  find "${STAGE}" -type f -name '*.php' -print0 | xargs -0 -n1 -P4 php -l
+fi
+
+echo "Creazione archivio: ${OUTPUT}"
+(
+  cd build
+  zip -r "../${OUTPUT}" "${SLUG}"
+)
+
+du -h "${OUTPUT}"
+echo "ARTIFACT=${OUTPUT}"
+echo "ARTIFACT_NAME=${ARTIFACT_NAME}"
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  {
+    echo "ARTIFACT=${OUTPUT}"
+    echo "ARTIFACT_NAME=${ARTIFACT_NAME}"
+  } >> "${GITHUB_OUTPUT}"
+fi


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that lints PHP, builds the plugin zip, uploads it as an artifact, and publishes releases on semantic tags
- create a packaging script that stages plugin files, validates syntax, and produces the versioned zip while exposing artifact metadata
- add repository-level ignore rules to keep build outputs and ancillary folders out of exported archives

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbefb1dc0c832f86ef7f33b7172572