### PR TITLE
Decode nested encoded host delimiters

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/bootstrap.php"
+         colors="true"
+         stopOnFailure="false"
+         failOnRisky="true"
+         failOnWarning="true">
+    <testsuites>
+        <testsuite name="FP Multilanguage">
+            <directory suffix="Test.php">tests/phpunit</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,86 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    define( 'ABSPATH', __DIR__ . '/../' );
+}
+
+if ( ! function_exists( 'wp_unslash' ) ) {
+    function wp_unslash( $value ) {
+        if ( is_array( $value ) ) {
+            return array_map( 'wp_unslash', $value );
+        }
+
+        return stripslashes( (string) $value );
+    }
+}
+
+if ( ! function_exists( 'wp_strip_all_tags' ) ) {
+    function wp_strip_all_tags( $string ) {
+        return strip_tags( $string );
+    }
+}
+
+if ( ! function_exists( 'is_ssl' ) ) {
+    function is_ssl() {
+        if ( isset( $_SERVER['HTTPS'] ) && 'off' !== strtolower( (string) $_SERVER['HTTPS'] ) ) {
+            return true;
+        }
+
+        return isset( $_SERVER['SERVER_PORT'] ) && 443 === (int) $_SERVER['SERVER_PORT'];
+    }
+}
+
+if ( ! function_exists( 'esc_url_raw' ) ) {
+    function esc_url_raw( $url ) {
+        return filter_var( $url, FILTER_UNSAFE_RAW, FILTER_FLAG_STRIP_LOW );
+    }
+}
+
+if ( ! function_exists( 'home_url' ) ) {
+    function home_url( $path = '', $scheme = null ) {
+        $path = (string) $path;
+
+        if ( '' !== $path && '/' !== $path[0] ) {
+            $path = '/' . $path;
+        }
+
+        $default_scheme = 'https';
+
+        if ( 'http' === $scheme || 'https' === $scheme ) {
+            $default_scheme = (string) $scheme;
+        } elseif ( 'relative' === $scheme ) {
+            return $path;
+        }
+
+        if ( '' === $path ) {
+            return sprintf( '%s://example.com', $default_scheme );
+        }
+
+        return sprintf( '%s://example.com%s', $default_scheme, $path );
+    }
+}
+
+if ( ! function_exists( 'trailingslashit' ) ) {
+    function trailingslashit( $string ) {
+        return untrailingslashit( $string ) . '/';
+    }
+}
+
+if ( ! function_exists( 'untrailingslashit' ) ) {
+    function untrailingslashit( $string ) {
+        return rtrim( (string) $string, "/\\" );
+    }
+}
+
+if ( ! function_exists( 'user_trailingslashit' ) ) {
+    function user_trailingslashit( $string ) {
+        return trailingslashit( rtrim( (string) $string, '/' ) );
+    }
+}
+
+if ( ! function_exists( 'wp_parse_url' ) ) {
+    function wp_parse_url( $url, $component = -1 ) {
+        return parse_url( $url, $component );
+    }
+}
+
+require_once __DIR__ . '/../fp-multilanguage/includes/class-language.php';

--- a/tests/phpunit/LanguageTest.php
+++ b/tests/phpunit/LanguageTest.php
@@ -1,0 +1,279 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+final class LanguageTest extends TestCase {
+    protected function setUp(): void {
+        parent::setUp();
+        $_SERVER = array();
+    }
+
+    public function test_get_current_url_preserves_port_information(): void {
+        $_SERVER['HTTP_HOST']   = 'example.com:8080';
+        $_SERVER['REQUEST_URI'] = '/path/page?foo=bar';
+
+        $language = ( new ReflectionClass( FPML_Language::class ) )->newInstanceWithoutConstructor();
+        $method   = new ReflectionMethod( FPML_Language::class, 'get_current_url' );
+        $method->setAccessible( true );
+
+        $this->assertSame(
+            'http://example.com:8080/path/page?foo=bar',
+            $method->invoke( $language )
+        );
+    }
+
+    public function test_get_current_url_falls_back_to_home_url_when_host_missing(): void {
+        $_SERVER['REQUEST_URI'] = '/current/page';
+        $_SERVER['HTTPS']       = 'on';
+
+        $language = ( new ReflectionClass( FPML_Language::class ) )->newInstanceWithoutConstructor();
+        $method   = new ReflectionMethod( FPML_Language::class, 'get_current_url' );
+        $method->setAccessible( true );
+
+        $this->assertSame(
+            'https://example.com/current/page',
+            $method->invoke( $language )
+        );
+    }
+
+    public function test_get_current_url_uses_site_scheme_when_not_ssl(): void {
+        $_SERVER['REQUEST_URI'] = '/current/page';
+
+        $language = ( new ReflectionClass( FPML_Language::class ) )->newInstanceWithoutConstructor();
+        $method   = new ReflectionMethod( FPML_Language::class, 'get_current_url' );
+        $method->setAccessible( true );
+
+        $this->assertSame(
+            'https://example.com/current/page',
+            $method->invoke( $language )
+        );
+    }
+
+    public function test_sanitize_host_allows_ipv6_notation_and_strips_noise(): void {
+        $_SERVER['HTTPS'] = 'on';
+
+        $language = ( new ReflectionClass( FPML_Language::class ) )->newInstanceWithoutConstructor();
+        $method   = new ReflectionMethod( FPML_Language::class, 'sanitize_host_header' );
+        $method->setAccessible( true );
+
+        $host = "[2001:db8::1]:8443\r\n";
+
+        $this->assertSame('[2001:db8::1]:8443', $method->invoke( $language, $host ));
+    }
+
+    public function test_sanitize_host_preserves_underscore_separators(): void {
+        $language = ( new ReflectionClass( FPML_Language::class ) )->newInstanceWithoutConstructor();
+        $method   = new ReflectionMethod( FPML_Language::class, 'sanitize_host_header' );
+        $method->setAccessible( true );
+
+        $this->assertSame(
+            'dev_site.local',
+            $method->invoke( $language, 'dev_site.local' )
+        );
+    }
+
+    public function test_sanitize_host_discards_invalid_port_suffix(): void {
+        $language = ( new ReflectionClass( FPML_Language::class ) )->newInstanceWithoutConstructor();
+        $method   = new ReflectionMethod( FPML_Language::class, 'sanitize_host_header' );
+        $method->setAccessible( true );
+
+        $this->assertSame(
+            'example.com',
+            $method->invoke( $language, 'example.com:bad' )
+        );
+    }
+
+    public function test_sanitize_host_discards_out_of_range_port_suffix(): void {
+        $language = ( new ReflectionClass( FPML_Language::class ) )->newInstanceWithoutConstructor();
+        $method   = new ReflectionMethod( FPML_Language::class, 'sanitize_host_header' );
+        $method->setAccessible( true );
+
+        $this->assertSame(
+            'example.com',
+            $method->invoke( $language, 'example.com:65536' )
+        );
+    }
+
+    public function test_sanitize_host_preserves_highest_valid_port_suffix(): void {
+        $language = ( new ReflectionClass( FPML_Language::class ) )->newInstanceWithoutConstructor();
+        $method   = new ReflectionMethod( FPML_Language::class, 'sanitize_host_header' );
+        $method->setAccessible( true );
+
+        $this->assertSame(
+            'example.com:65535',
+            $method->invoke( $language, 'example.com:65535' )
+        );
+    }
+
+    public function test_sanitize_host_discards_invalid_ipv6_port_suffix(): void {
+        $language = ( new ReflectionClass( FPML_Language::class ) )->newInstanceWithoutConstructor();
+        $method   = new ReflectionMethod( FPML_Language::class, 'sanitize_host_header' );
+        $method->setAccessible( true );
+
+        $this->assertSame(
+            '[2001:db8::1]',
+            $method->invoke( $language, '[2001:db8::1]:bad' )
+        );
+    }
+
+    public function test_sanitize_host_discards_out_of_range_ipv6_port_suffix(): void {
+        $language = ( new ReflectionClass( FPML_Language::class ) )->newInstanceWithoutConstructor();
+        $method   = new ReflectionMethod( FPML_Language::class, 'sanitize_host_header' );
+        $method->setAccessible( true );
+
+        $this->assertSame(
+            '[2001:db8::1]',
+            $method->invoke( $language, '[2001:db8::1]:99999' )
+        );
+    }
+
+    public function test_sanitize_host_preserves_highest_valid_ipv6_port_suffix(): void {
+        $language = ( new ReflectionClass( FPML_Language::class ) )->newInstanceWithoutConstructor();
+        $method   = new ReflectionMethod( FPML_Language::class, 'sanitize_host_header' );
+        $method->setAccessible( true );
+
+        $this->assertSame(
+            '[2001:db8::1]:65535',
+            $method->invoke( $language, '[2001:db8::1]:65535' )
+        );
+    }
+
+    public function test_sanitize_host_preserves_ipv6_zone_identifier(): void {
+        $language = ( new ReflectionClass( FPML_Language::class ) )->newInstanceWithoutConstructor();
+        $method   = new ReflectionMethod( FPML_Language::class, 'sanitize_host_header' );
+        $method->setAccessible( true );
+
+        $this->assertSame(
+            '[fe80::1%25eth0]',
+            $method->invoke( $language, '[fe80::1%25eth0]' )
+        );
+    }
+
+    public function test_sanitize_host_strips_percent_from_hostname(): void {
+        $language = ( new ReflectionClass( FPML_Language::class ) )->newInstanceWithoutConstructor();
+        $method   = new ReflectionMethod( FPML_Language::class, 'sanitize_host_header' );
+        $method->setAccessible( true );
+
+        $this->assertSame(
+            'example.com',
+            $method->invoke( $language, 'example.com%25' )
+        );
+    }
+
+    public function test_sanitize_host_discards_data_after_encoded_null_byte(): void {
+        $language = ( new ReflectionClass( FPML_Language::class ) )->newInstanceWithoutConstructor();
+        $method   = new ReflectionMethod( FPML_Language::class, 'sanitize_host_header' );
+        $method->setAccessible( true );
+
+        $this->assertSame(
+            'example.com',
+            $method->invoke( $language, 'example.com%00.evil.com' )
+        );
+    }
+
+    public function test_sanitize_host_decodes_encoded_path_delimiters(): void {
+        $language = ( new ReflectionClass( FPML_Language::class ) )->newInstanceWithoutConstructor();
+        $method   = new ReflectionMethod( FPML_Language::class, 'sanitize_host_header' );
+        $method->setAccessible( true );
+
+        $this->assertSame(
+            'example.com',
+            $method->invoke( $language, 'example.com%2F..%2Fadmin' )
+        );
+    }
+
+    public function test_sanitize_host_decodes_double_encoded_path_delimiters(): void {
+        $language = ( new ReflectionClass( FPML_Language::class ) )->newInstanceWithoutConstructor();
+        $method   = new ReflectionMethod( FPML_Language::class, 'sanitize_host_header' );
+        $method->setAccessible( true );
+
+        $this->assertSame(
+            'example.com',
+            $method->invoke( $language, 'example.com%252F..%252Fadmin' )
+        );
+    }
+
+    public function test_sanitize_host_decodes_encoded_scheme_and_query_separators(): void {
+        $language = ( new ReflectionClass( FPML_Language::class ) )->newInstanceWithoutConstructor();
+        $method   = new ReflectionMethod( FPML_Language::class, 'sanitize_host_header' );
+        $method->setAccessible( true );
+
+        $this->assertSame(
+            'example.com:8443',
+            $method->invoke( $language, 'https%3A%2F%2Fexample.com%3A8443%3Ffoo%3Dbar' )
+        );
+    }
+
+    public function test_sanitize_host_decodes_double_encoded_scheme_and_query_separators(): void {
+        $language = ( new ReflectionClass( FPML_Language::class ) )->newInstanceWithoutConstructor();
+        $method   = new ReflectionMethod( FPML_Language::class, 'sanitize_host_header' );
+        $method->setAccessible( true );
+
+        $this->assertSame(
+            'example.com:8443',
+            $method->invoke( $language, 'https%253A%252F%252Fexample.com%253A8443%253Ffoo%253Dbar' )
+        );
+    }
+
+    public function test_sanitize_host_discards_scheme_and_userinfo_from_header(): void {
+        $language = ( new ReflectionClass( FPML_Language::class ) )->newInstanceWithoutConstructor();
+        $method   = new ReflectionMethod( FPML_Language::class, 'sanitize_host_header' );
+        $method->setAccessible( true );
+
+        $this->assertSame(
+            'example.com:8080',
+            $method->invoke( $language, 'https://user:pass@example.com:8080/path' )
+        );
+    }
+
+    public function test_sanitize_host_handles_schemeless_authority_in_header(): void {
+        $language = ( new ReflectionClass( FPML_Language::class ) )->newInstanceWithoutConstructor();
+        $method   = new ReflectionMethod( FPML_Language::class, 'sanitize_host_header' );
+        $method->setAccessible( true );
+
+        $this->assertSame(
+            'example.com',
+            $method->invoke( $language, '//example.com/segment' )
+        );
+    }
+
+    public function test_sanitize_host_removes_scheme_only_prefix(): void {
+        $language = ( new ReflectionClass( FPML_Language::class ) )->newInstanceWithoutConstructor();
+        $method   = new ReflectionMethod( FPML_Language::class, 'sanitize_host_header' );
+        $method->setAccessible( true );
+
+        $this->assertSame(
+            'example.com',
+            $method->invoke( $language, 'http://example.com' )
+        );
+    }
+
+    public function test_sanitize_request_uri_normalizes_without_clobbering_query(): void {
+        $language = ( new ReflectionClass( FPML_Language::class ) )->newInstanceWithoutConstructor();
+        $method   = new ReflectionMethod( FPML_Language::class, 'sanitize_request_uri' );
+        $method->setAccessible( true );
+
+        $uri = "//current/page?foo=bar#section";
+
+        $this->assertSame('/current/page?foo=bar#section', $method->invoke( $language, $uri ));
+    }
+
+    public function test_sanitize_request_uri_strips_scheme_and_host_from_absolute_uri(): void {
+        $language = ( new ReflectionClass( FPML_Language::class ) )->newInstanceWithoutConstructor();
+        $method   = new ReflectionMethod( FPML_Language::class, 'sanitize_request_uri' );
+        $method->setAccessible( true );
+
+        $uri = 'https://malicious.test/path/page?foo=bar#section';
+
+        $this->assertSame('/path/page?foo=bar#section', $method->invoke( $language, $uri ));
+    }
+
+    public function test_sanitize_request_uri_trims_extraneous_whitespace(): void {
+        $language = ( new ReflectionClass( FPML_Language::class ) )->newInstanceWithoutConstructor();
+        $method   = new ReflectionMethod( FPML_Language::class, 'sanitize_request_uri' );
+        $method->setAccessible( true );
+
+        $uri = "   /current/page?foo=bar   ";
+
+        $this->assertSame('/current/page?foo=bar', $method->invoke( $language, $uri ));
+    }
+}


### PR DESCRIPTION
## Summary
- stop host sanitization at the first control character encountered so encoded null bytes cannot leak attacker-controlled suffixes into the computed authority
- cover encoded null byte handling with a regression test for the language host sanitizer
- drop out-of-range port suffixes from sanitized hosts while preserving the highest valid port for IPv4 and IPv6 authorities
- add PHPUnit coverage for rejecting out-of-range host ports and keeping the boundary value 65535
- repeatedly decode percent-encoded host headers so double-encoded delimiters cannot survive sanitization and pollute the computed authority
- add regression tests covering double-encoded path, scheme, and query separators for the host sanitizer

## Testing
- fp-multilanguage/vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68dd3be0d42c832f9ee1e0cc9d4d06a5