### PR TITLE
Fix plugin build syntax errors

### DIFF
--- a/fp-multilanguage/includes/class-plugin.php
+++ b/fp-multilanguage/includes/class-plugin.php
@@ -257,7 +257,8 @@ protected function define_hooks() {
                         add_action( 'save_post', array( $this, 'handle_save_post' ), 20, 3 );
                         add_action( 'created_term', array( $this, 'handle_created_term' ), 10, 3 );
                         add_action( 'edited_term', array( $this, 'handle_edited_term' ), 10, 3 );
-}
+                }
+        }
 
         /**
          * Ensure heavy options are stored without autoload.
@@ -299,7 +300,6 @@ protected function define_hooks() {
 
                 update_option( self::OPTION_AUTOLOAD_MIGRATED, 1, false );
         }
-}
 
         /**
          * Handle post save events to ensure translations and enqueue jobs.

--- a/fp-multilanguage/includes/class-settings.php
+++ b/fp-multilanguage/includes/class-settings.php
@@ -172,41 +172,41 @@ foreach ( $all as $taxonomy ) {
 if ( 0 === strpos( $taxonomy, 'pa_' ) ) {
 $taxonomies[] = $taxonomy;
 }
-
-    /**
-     * Flush rewrite rules when routing mode changes.
-     *
-     * @since 0.2.0
-     *
-     * @param array $old_value Previous option value.
-     * @param array $value     New option value.
-     * @param string $option   Option name.
-     *
-     * @return void
-     */
-    public function maybe_flush_rewrites( $old_value, $value, $option ) {
-        unset( $option );
-
-        $old_value = is_array( $old_value ) ? $old_value : array();
-        $value     = is_array( $value ) ? $value : array();
-        $defaults  = $this->get_defaults();
-
-        $old_mode = isset( $old_value['routing_mode'] ) ? $old_value['routing_mode'] : $defaults['routing_mode'];
-        $new_mode = isset( $value['routing_mode'] ) ? $value['routing_mode'] : $old_mode;
-
-        if ( $old_mode === $new_mode ) {
-            return;
-        }
-
-        if ( class_exists( 'FPML_Rewrites' ) ) {
-            FPML_Rewrites::instance()->register_rewrites();
-        }
-
-        flush_rewrite_rules( false );
-    }
 }
 
 return array_values( array_unique( $taxonomies ) );
+}
+
+/**
+ * Flush rewrite rules when routing mode changes.
+ *
+ * @since 0.2.0
+ *
+ * @param array $old_value Previous option value.
+ * @param array $value     New option value.
+ * @param string $option   Option name.
+ *
+ * @return void
+ */
+public function maybe_flush_rewrites( $old_value, $value, $option ) {
+unset( $option );
+
+$old_value = is_array( $old_value ) ? $old_value : array();
+$value     = is_array( $value ) ? $value : array();
+$defaults  = $this->get_defaults();
+
+$old_mode = isset( $old_value['routing_mode'] ) ? $old_value['routing_mode'] : $defaults['routing_mode'];
+$new_mode = isset( $value['routing_mode'] ) ? $value['routing_mode'] : $old_mode;
+
+if ( $old_mode === $new_mode ) {
+return;
+}
+
+if ( class_exists( 'FPML_Rewrites' ) ) {
+FPML_Rewrites::instance()->register_rewrites();
+}
+
+flush_rewrite_rules( false );
 }
 
 /**


### PR DESCRIPTION
## Summary
- fix the WooCommerce taxonomy helper so it closes the loop before declaring `maybe_flush_rewrites`, eliminating the parse error
- close the remaining brace blocks in the plugin bootstrap helpers so the plugin file parses correctly

## Testing
- ./scripts/build-zip.sh

------
https://chatgpt.com/codex/tasks/task_e_68e140d29b24832fbbfafb4a581abed3