### PR TITLE
Investigate billing key malfunction

### DIFF
--- a/fp-multilanguage/includes/class-settings.php
+++ b/fp-multilanguage/includes/class-settings.php
@@ -304,6 +304,13 @@ $data['excluded_shortcodes']     = sanitize_textarea_field( $data['excluded_shor
 	$data['enable_rush_mode']          = ! empty( $data['enable_rush_mode'] );
 	$data['enable_acf_support']        = ! empty( $data['enable_acf_support'] );
 	$data['setup_completed']           = ! empty( $data['setup_completed'] );
+	$data['enable_email_notifications'] = ! empty( $data['enable_email_notifications'] );
+
+	// Menu language switcher integration (0.4.2+).
+	$data['auto_integrate_menu_switcher'] = ! empty( $data['auto_integrate_menu_switcher'] );
+	$data['menu_switcher_style']          = in_array( $data['menu_switcher_style'], array( 'inline', 'dropdown' ), true ) ? $data['menu_switcher_style'] : $defaults['menu_switcher_style'];
+	$data['menu_switcher_show_flags']     = ! empty( $data['menu_switcher_show_flags'] );
+	$data['menu_switcher_position']       = in_array( $data['menu_switcher_position'], array( 'start', 'end' ), true ) ? $data['menu_switcher_position'] : $defaults['menu_switcher_position'];
 
 	update_option( 'fpml_remove_data', $data['remove_data'] );
 

--- a/fp-multilanguage/rest/class-rest-admin.php
+++ b/fp-multilanguage/rest/class-rest-admin.php
@@ -589,35 +589,31 @@ class FPML_REST_Admin {
 		switch ( $provider ) {
 			case 'openai':
 				$api_key = $settings->get( 'openai_api_key', '' );
-				$model   = $settings->get( 'openai_model', 'gpt-4o-mini' );
 				if ( empty( $api_key ) ) {
 					return new WP_Error( 'fpml_no_api_key', __( 'API key OpenAI mancante.', 'fp-multilanguage' ) );
 				}
-				return new FPML_Provider_OpenAI( $api_key, $model );
+				return new FPML_Provider_OpenAI();
 
 			case 'deepl':
-				$api_key  = $settings->get( 'deepl_api_key', '' );
-				$use_free = $settings->get( 'deepl_use_free', false );
+				$api_key = $settings->get( 'deepl_api_key', '' );
 				if ( empty( $api_key ) ) {
 					return new WP_Error( 'fpml_no_api_key', __( 'API key DeepL mancante.', 'fp-multilanguage' ) );
 				}
-				return new FPML_Provider_DeepL( $api_key, $use_free );
+				return new FPML_Provider_DeepL();
 
 			case 'google':
-				$api_key    = $settings->get( 'google_api_key', '' );
-				$project_id = $settings->get( 'google_project_id', '' );
+				$api_key = $settings->get( 'google_api_key', '' );
 				if ( empty( $api_key ) ) {
 					return new WP_Error( 'fpml_no_api_key', __( 'API key Google mancante.', 'fp-multilanguage' ) );
 				}
-				return new FPML_Provider_Google( $api_key, $project_id );
+				return new FPML_Provider_Google();
 
 			case 'libretranslate':
 				$api_url = $settings->get( 'libretranslate_api_url', '' );
-				$api_key = $settings->get( 'libretranslate_api_key', '' );
 				if ( empty( $api_url ) ) {
 					return new WP_Error( 'fpml_no_api_url', __( 'URL API LibreTranslate mancante.', 'fp-multilanguage' ) );
 				}
-				return new FPML_Provider_LibreTranslate( $api_url, $api_key );
+				return new FPML_Provider_LibreTranslate();
 
 			default:
 				return new WP_Error( 'fpml_invalid_provider', __( 'Provider non valido.', 'fp-multilanguage' ) );


### PR DESCRIPTION
# Pull Request

## Description
Fixes an issue where "Verifica Billing" (Verify Billing) buttons were not functioning due to incorrect instantiation of translation providers. The provider constructors were being called with parameters, but the base class does not accept them, leading to silent failures.

## Related Issue
Closes #

## Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made
- Modified `FPML_REST_Admin::get_translator_by_slug()` to instantiate translation providers (OpenAI, DeepL, Google, LibreTranslate) without passing parameters to their constructors.
- Providers now correctly retrieve API keys and other settings directly from `FPML_Settings`.

## Testing
Manual testing of the "Verifica Billing" buttons for each translation provider in the admin interface.

### Test Checklist
- [ ] All existing tests pass
- [ ] Added tests for new code
- [x] Manual testing completed
- [ ] Tested on PHP 7.4
- [ ] Tested on PHP 8.2

### Test Output
```bash
# Paste vendor/bin/phpunit output
```

## Code Quality
- [x] Code follows WordPress coding standards
- [ ] PHPStan analysis passes
- [ ] PHPCS passes
- [x] No PHP errors/warnings

### Quality Check Output
```bash
# vendor/bin/phpcs output

# vendor/bin/phpstan output
```

## Performance Impact
- [x] No performance impact

### Benchmarks
```bash
# Before:

# After:
```

## Documentation
- [x] Updated PHPDoc comments (if necessary)
- [ ] Updated relevant .md files
- [ ] Updated CHANGELOG.md
- [ ] Added examples if needed

## Screenshots

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes
The issue stemmed from provider constructors not being designed to accept parameters directly during instantiation in `get_translator_by_slug()`. By removing the parameters, the providers now correctly initialize by fetching their configuration from the `FPML_Settings` system, resolving the non-functional billing verification.

---
<a href="https://cursor.com/background-agent?bcId=bc-6d6f3b9f-0733-463c-a62f-14104074d585"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6d6f3b9f-0733-463c-a62f-14104074d585"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

