### PR TITLE
Fix early health-check translation loading

### DIFF
--- a/fp-multilanguage/includes/core/class-plugin.php
+++ b/fp-multilanguage/includes/core/class-plugin.php
@@ -226,6 +226,17 @@ class FPML_Plugin_Core {
 	}
 
 	/**
+	 * Load plugin text domain for translations.
+	 *
+	 * @since 0.4.1
+	 *
+	 * @return void
+	 */
+	public function load_textdomain() {
+		load_plugin_textdomain( 'fp-multilanguage', false, dirname( plugin_basename( FPML_PLUGIN_FILE ) ) . '/languages' );
+	}
+
+	/**
 	 * Detect active multilingual plugins that require assisted mode.
 	 *
 	 * @since 0.2.0
@@ -308,7 +319,8 @@ class FPML_Plugin_Core {
 	 * @return void
 	 */
 	protected function define_hooks() {
-		load_plugin_textdomain( 'fp-multilanguage', false, dirname( plugin_basename( FPML_PLUGIN_FILE ) ) . '/languages' );
+		// Load translations at init to comply with WordPress 6.7.0+ requirements
+		add_action( 'init', array( $this, 'load_textdomain' ) );
 
 		// Classi base (testate e funzionanti)
 		FPML_Settings::instance();


### PR DESCRIPTION
# Pull Request

## Description
Addresses a PHP Notice regarding `_load_textdomain_just_in_time` being called incorrectly. Translations for the `fp-multilanguage` text domain were loaded too early, before the `init` action, which violates WordPress 6.7.0+ requirements. This change ensures translations are loaded at the appropriate `init` hook, resolving the notice.

## Related Issue
Closes #

## Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made
- Created a new `load_textdomain()` method within `FPML_Plugin_Core` to encapsulate the `load_plugin_textdomain()` call.
- Replaced the direct call to `load_plugin_textdomain()` in `define_hooks()` with an `add_action('init', ...)` hook to defer translation loading until the `init` action.

## Testing
The AI performed the following checks:
- Verified no other early textdomain loads in the codebase.
- Ran PHP linting (`php -l`) on the modified file, which passed without errors.
- Manual testing would involve verifying the PHP Notice no longer appears and plugin translations function as expected.

### Test Checklist
- [ ] All existing tests pass
- [ ] Added tests for new code
- [ ] Manual testing completed
- [ ] Tested on PHP 7.4
- [ ] Tested on PHP 8.2

### Test Output
```bash
# No phpunit output provided by the AI
```

## Code Quality
- [ ] Code follows WordPress coding standards
- [ ] PHPStan analysis passes
- [ ] PHPCS passes
- [x] No PHP errors/warnings

### Quality Check Output
```bash
# vendor/bin/phpcs output

# vendor/bin/phpstan output
```

## Performance Impact
- [x] No performance impact

### Benchmarks
```bash
# Before:

# After:
```

## Documentation
- [x] Updated PHPDoc comments
- [ ] Updated relevant .md files
- [ ] Updated CHANGELOG.md
- [ ] Added examples if needed

## Screenshots
N/A

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes
This change specifically addresses the `_load_textdomain_just_in_time` PHP Notice introduced in WordPress 6.7.0, which requires translation loading to occur at the `init` action or later.

---
<a href="https://cursor.com/background-agent?bcId=bc-2a8dee65-ae94-470c-a7bc-95170122e8b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2a8dee65-ae94-470c-a7bc-95170122e8b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

